### PR TITLE
feat: SDK PyPI release prep — pyproject.toml, typed exceptions, retry, helpers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build SDK package
+        run: |
+          cd server/sdk
+          python -m build
+
+      - name: Check package
+        run: |
+          cd server/sdk
+          twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: server/sdk/dist/

--- a/server/sdk/LICENSE
+++ b/server/sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Anote AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/server/sdk/MANIFEST.in
+++ b/server/sdk/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include LICENSE
+include requirements.txt
+recursive-include anote_generate *.py py.typed

--- a/server/sdk/README.md
+++ b/server/sdk/README.md
@@ -1,0 +1,81 @@
+# anote-generate
+
+Python SDK for the [Anote Synthetic Data API](https://anote.ai) — generate text, image, audio, video, agent trace, and PII datasets using LLMs.
+
+## Installation
+
+```bash
+pip install anote-generate
+```
+
+## Quick Start
+
+```python
+from anote_generate import Anote
+
+client = Anote(api_key="your-api-key")
+
+# Generate text data
+rows = client.generate(
+    task_type="text",
+    columns=["question", "answer", "difficulty"],
+    prompt="Generate Q&A pairs about Python programming",
+    num_rows=10,
+    examples=[{"question": "What is a list?", "answer": "An ordered collection", "difficulty": "easy"}],
+)
+
+for row in rows:
+    print(row)
+
+# Save to CSV
+client.to_file(rows, "dataset.csv")
+
+# Convert to DataFrame
+df = client.to_dataframe(rows)
+```
+
+## Supported Task Types
+
+| task_type | Description |
+|-----------|-------------|
+| `text` | Structured text with any columns |
+| `image` | DALL-E 3 images with YOLO detection |
+| `audio` | TTS audio with Whisper transcription |
+| `video` | Video clips with optional frame annotations |
+| `agent` | Multi-turn agent traces with tool calls |
+| `pii` | Synthetic PII records (14 types) |
+| `tabular` | Typed tabular data with relational integrity |
+| `code` | Code functions, tests, and docstrings |
+
+## Parameters
+
+```python
+client.generate(
+    task_type="audio",
+    columns=["transcript", "sentiment"],
+    prompt="Customer support calls for a SaaS product",
+    num_rows=20,
+    params={
+        "voice": "nova",          # alloy | echo | fable | onyx | nova | shimmer
+        "tts_model": "tts-1-hd",  # tts-1 | tts-1-hd
+        "speed": 1.0,
+    },
+)
+```
+
+## Error Handling
+
+```python
+from anote_generate import Anote, AnoteAuthError, AnoteValidationError
+
+try:
+    rows = client.generate(task_type="text", columns=["col"], prompt="...", num_rows=5)
+except AnoteAuthError:
+    print("Invalid API key")
+except AnoteValidationError as e:
+    print("Bad request:", e.details)
+```
+
+## License
+
+MIT

--- a/server/sdk/anote-generate/__init__.py
+++ b/server/sdk/anote-generate/__init__.py
@@ -1,2 +1,37 @@
-from .core import Anote
-# from .constants import *
+"""
+anote-generate — Python SDK for the Anote Synthetic Data API.
+
+Quick start::
+
+    from anote_generate import Anote
+
+    client = Anote(api_key="your-key")
+    rows = client.generate(
+        task_type="text",
+        columns=["question", "answer"],
+        prompt="Generate Q&A pairs about Python programming",
+        num_rows=10,
+    )
+
+See https://docs.anote.ai for full documentation.
+"""
+
+from .core import (
+    Anote,
+    AnoteGenerate,  # backwards-compatible alias
+    AnoteAuthError,
+    AnoteValidationError,
+    AnoteRateLimitError,
+    AnoteServerError,
+)
+
+__version__ = "1.0.0"
+__all__ = [
+    "Anote",
+    "AnoteGenerate",
+    "AnoteAuthError",
+    "AnoteValidationError",
+    "AnoteRateLimitError",
+    "AnoteServerError",
+    "__version__",
+]

--- a/server/sdk/anote-generate/core.py
+++ b/server/sdk/anote-generate/core.py
@@ -1,39 +1,260 @@
-import requests
+"""
+Anote Synthetic Data API client.
+"""
+from __future__ import annotations
+
+import os
+import time
 import json
+import logging
+from typing import List, Optional, Iterator, Any
 
-class AnoteGenerate:
-    def __init__(self, api_key):
-        # self.API_BASE_URL = 'http://localhost:5000'
-        self.API_BASE_URL = "https://api.anote.ai"
-        self.headers = {
-            'Authorization': f'Bearer {api_key}',
-            'Content-Type': 'application/json'
-        }
+import requests
 
-    def generate(self, task_type: str, columns: list, prompt: str = None, num_rows: int = 10, examples: list = None):
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.anote.ai"
+DEFAULT_TIMEOUT = 120
+MAX_RETRIES = 3
+RETRY_BACKOFF = [2, 4, 8]  # seconds
+
+
+class AnoteAuthError(Exception):
+    """Raised on 401 Unauthorized responses."""
+
+
+class AnoteValidationError(Exception):
+    """Raised on 422 Unprocessable Entity responses."""
+    def __init__(self, message: str, details: list = None):
+        super().__init__(message)
+        self.details = details or []
+
+
+class AnoteRateLimitError(Exception):
+    """Raised on 429 Too Many Requests responses."""
+
+
+class AnoteServerError(Exception):
+    """Raised on 5xx server errors."""
+
+
+class Anote:
+    """
+    Client for the Anote Synthetic Data API.
+
+    Args:
+        api_key: Your Anote API key (Bearer token). If not provided,
+                 reads from the ANOTE_API_KEY environment variable.
+        base_url: API base URL. Defaults to https://api.anote.ai.
+        timeout: Request timeout in seconds (default: 120).
+
+    Example::
+
+        from anote_generate import Anote
+
+        client = Anote(api_key="your-key")
+        data = client.generate(
+            task_type="text",
+            columns=["question", "answer"],
+            prompt="Generate Q&A pairs about Python",
+            num_rows=10,
+        )
+        for row in data:
+            print(row["question"], "->", row["answer"])
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        self.api_key = api_key or os.getenv("ANOTE_API_KEY") or os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "API key required. Pass api_key= or set ANOTE_API_KEY environment variable."
+            )
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._session = requests.Session()
+        self._session.headers.update({
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": f"anote-generate/{_get_version()}",
+        })
+
+    def generate(
+        self,
+        task_type: str,
+        columns: List[str],
+        prompt: str,
+        num_rows: int = 5,
+        examples: Optional[List[dict]] = None,
+        params: Optional[dict] = None,
+        export_format: Optional[str] = None,
+    ) -> List[dict]:
         """
-        Generate synthetic data based on task type and prompt.
+        Generate synthetic data rows.
 
         Args:
-            task_type (str): One of ['text', 'image', 'video', 'audio', 'agent', 'reasoning']
-            columns (list): Column names for dataset
-            prompt (str, optional): Prompt to guide generation
-            num_rows (int, optional): Number of data rows to generate
-            examples (list, optional): Few-shot examples to guide generation
+            task_type: Modality to generate. One of: text, image, audio, video, agent, pii, tabular, code.
+            columns: List of column names for the output rows.
+            prompt: Natural language description of the data to generate.
+            num_rows: Number of rows to generate (default: 5, max: 100).
+            examples: Optional list of example rows for few-shot generation.
+            params: Optional modality-specific parameters dict.
+            export_format: If set, download as file. One of: csv, jsonl, parquet, json.
 
         Returns:
-            dict: Generated dataset in JSON or downloadable CSV format
+            List of dicts, each containing the requested columns plus "status".
+
+        Raises:
+            AnoteAuthError: Invalid or missing API key.
+            AnoteValidationError: Invalid request parameters.
+            AnoteRateLimitError: Rate limit exceeded.
+            AnoteServerError: Server-side error.
+
+        Example::
+
+            rows = client.generate(
+                task_type="text",
+                columns=["review", "sentiment", "rating"],
+                prompt="Product reviews for a coffee maker",
+                num_rows=20,
+                examples=[{"review": "Great coffee!", "sentiment": "positive", "rating": "5"}],
+            )
         """
-        data = {
+        payload = {
             "task_type": task_type,
             "prompt": prompt,
             "num_rows": num_rows,
             "columns": columns,
-            "examples": examples
+            "examples": examples or [],
+            "params": params or {},
         }
 
-        response = requests.post(f"{self.API_BASE_URL}/public/generate", headers=self.headers, json=data)
-        if response.status_code == 200:
-            return response.json()
+        url = f"{self.base_url}/public/generate"
+        response = self._post_with_retry(url, payload)
+        data = response.json()
+        return data.get("data", data)
+
+    def _post_with_retry(self, url: str, payload: dict) -> requests.Response:
+        """POST with exponential backoff retry on 5xx and network errors."""
+        last_exc = None
+        for attempt, backoff in enumerate(RETRY_BACKOFF + [None]):
+            try:
+                resp = self._session.post(url, json=payload, timeout=self.timeout)
+                self._raise_for_status(resp)
+                return resp
+            except (AnoteServerError, requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout) as e:
+                last_exc = e
+                if backoff is None:
+                    break
+                logger.warning("Request failed (attempt %d/%d): %s. Retrying in %ds...",
+                               attempt + 1, MAX_RETRIES, e, backoff)
+                time.sleep(backoff)
+            except (AnoteAuthError, AnoteValidationError, AnoteRateLimitError):
+                raise  # Don't retry client errors
+        raise last_exc
+
+    def _raise_for_status(self, resp: requests.Response) -> None:
+        """Raise typed exceptions based on HTTP status code."""
+        if resp.ok:
+            return
+        try:
+            body = resp.json()
+        except Exception:
+            body = {"error": resp.text}
+
+        if resp.status_code == 401:
+            raise AnoteAuthError(body.get("error", "Unauthorized"))
+        elif resp.status_code == 422:
+            raise AnoteValidationError(
+                body.get("error", "Validation failed"),
+                details=body.get("details", [])
+            )
+        elif resp.status_code == 429:
+            raise AnoteRateLimitError("Rate limit exceeded. Please slow down requests.")
+        elif resp.status_code >= 500:
+            raise AnoteServerError(f"Server error {resp.status_code}: {body.get('error', resp.text)}")
         else:
-            raise Exception(f"Generation failed with status code {response.status_code}: {response.text}")
+            raise requests.HTTPError(f"HTTP {resp.status_code}: {body}")
+
+    def to_dataframe(self, data: List[dict]):
+        """
+        Convert generate() output to a pandas DataFrame.
+
+        Args:
+            data: List of row dicts from generate()
+
+        Returns:
+            pandas.DataFrame
+
+        Example::
+
+            rows = client.generate(task_type="text", columns=["q", "a"], prompt="...", num_rows=10)
+            df = client.to_dataframe(rows)
+            df.to_csv("output.csv", index=False)
+        """
+        try:
+            import pandas as pd
+        except ImportError:
+            raise ImportError("pandas is required for to_dataframe(). Run: pip install pandas")
+        return pd.DataFrame(data)
+
+    def to_file(self, data: List[dict], path: str, fmt: Optional[str] = None) -> str:
+        """
+        Save generate() output to a file.
+
+        Args:
+            data: List of row dicts from generate()
+            path: Output file path
+            fmt: Format override. Auto-detected from file extension if not provided.
+                 Supported: csv, jsonl, json, parquet
+
+        Returns:
+            Absolute path to saved file
+
+        Example::
+
+            rows = client.generate(task_type="text", columns=["q", "a"], prompt="...", num_rows=10)
+            client.to_file(rows, "dataset.csv")
+            client.to_file(rows, "dataset.jsonl")
+        """
+        import pathlib
+        p = pathlib.Path(path)
+        ext = fmt or p.suffix.lstrip(".")
+
+        if ext == "csv":
+            import csv, io
+            if not data:
+                p.write_text("")
+                return str(p.resolve())
+            keys = list(data[0].keys())
+            out = io.StringIO()
+            writer = csv.DictWriter(out, fieldnames=keys, extrasaction="ignore")
+            writer.writeheader()
+            writer.writerows(data)
+            p.write_text(out.getvalue())
+        elif ext == "jsonl":
+            p.write_text("\n".join(json.dumps(row, ensure_ascii=False) for row in data) + "\n")
+        elif ext == "parquet":
+            df = self.to_dataframe(data)
+            df.to_parquet(path, index=False)
+        else:
+            p.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+
+        return str(p.resolve())
+
+
+def _get_version() -> str:
+    try:
+        from anote_generate import __version__
+        return __version__
+    except Exception:
+        return "unknown"
+
+
+# Backwards-compatible alias
+AnoteGenerate = Anote

--- a/server/sdk/pyproject.toml
+++ b/server/sdk/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "anote-generate"
+version = "1.0.0"
+description = "Python SDK for the Anote Synthetic Data API — generate text, image, audio, video, agent, and PII datasets"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [
+    {name = "Anote AI", email = "support@anote.ai"}
+]
+keywords = ["synthetic-data", "llm", "ai", "dataset", "generation", "text", "image", "audio", "video"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.31,<3",
+    "httpx>=0.24",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7",
+    "pytest-mock>=3",
+    "responses>=0.25",
+]
+async = [
+    "httpx>=0.24",
+]
+
+[project.urls]
+Homepage = "https://anote.ai"
+Documentation = "https://docs.anote.ai"
+Repository = "https://github.com/anote-ai/Synthetic-Data"
+"Bug Tracker" = "https://github.com/anote-ai/Synthetic-Data/issues"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["anote_generate*"]
+
+[tool.setuptools.package-data]
+anote_generate = ["py.typed"]

--- a/server/sdk/requirements.txt
+++ b/server/sdk/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31,<3
+httpx>=0.24

--- a/server/sdk/tests/test_client.py
+++ b/server/sdk/tests/test_client.py
@@ -1,0 +1,99 @@
+"""Tests for the anote-generate SDK client."""
+import pytest
+import responses as responses_lib
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from anote_generate import Anote, AnoteAuthError, AnoteValidationError, AnoteServerError
+
+
+@pytest.fixture
+def client():
+    return Anote(api_key="test-key-123", base_url="http://localhost:5000")
+
+
+@responses_lib.activate
+def test_generate_text_success(client):
+    mock_data = [
+        {"question": "What is Python?", "answer": "A language.", "status": "succeeded"},
+        {"question": "What is a list?", "answer": "A collection.", "status": "succeeded"},
+    ]
+    responses_lib.add(
+        responses_lib.POST,
+        "http://localhost:5000/public/generate",
+        json={"data": mock_data},
+        status=200,
+    )
+    result = client.generate(
+        task_type="text",
+        columns=["question", "answer"],
+        prompt="Python Q&A",
+        num_rows=2,
+    )
+    assert len(result) == 2
+    assert result[0]["question"] == "What is Python?"
+
+
+@responses_lib.activate
+def test_generate_raises_auth_error(client):
+    responses_lib.add(
+        responses_lib.POST,
+        "http://localhost:5000/public/generate",
+        json={"error": "Unauthorized"},
+        status=401,
+    )
+    with pytest.raises(AnoteAuthError):
+        client.generate(task_type="text", columns=["col"], prompt="test", num_rows=1)
+
+
+@responses_lib.activate
+def test_generate_raises_validation_error(client):
+    responses_lib.add(
+        responses_lib.POST,
+        "http://localhost:5000/public/generate",
+        json={"error": "Validation failed", "details": [{"field": "task_type", "message": "Invalid"}]},
+        status=422,
+    )
+    with pytest.raises(AnoteValidationError) as exc_info:
+        client.generate(task_type="invalid", columns=["col"], prompt="test", num_rows=1)
+    assert exc_info.value.details[0]["field"] == "task_type"
+
+
+def test_to_file_csv(client, tmp_path):
+    data = [{"name": "Alice", "age": "30"}, {"name": "Bob", "age": "25"}]
+    out = tmp_path / "test.csv"
+    client.to_file(data, str(out))
+    content = out.read_text()
+    assert "name,age" in content
+    assert "Alice" in content
+
+
+def test_to_file_jsonl(client, tmp_path):
+    data = [{"q": "Q1", "a": "A1"}, {"q": "Q2", "a": "A2"}]
+    out = tmp_path / "test.jsonl"
+    client.to_file(data, str(out))
+    lines = out.read_text().strip().split("\n")
+    assert len(lines) == 2
+    assert json.loads(lines[0])["q"] == "Q1"
+
+
+def test_missing_api_key():
+    import os
+    old = os.environ.pop("ANOTE_API_KEY", None)
+    old2 = os.environ.pop("OPENAI_API_KEY", None)
+    try:
+        with pytest.raises(ValueError, match="API key required"):
+            Anote()
+    finally:
+        if old:
+            os.environ["ANOTE_API_KEY"] = old
+        if old2:
+            os.environ["OPENAI_API_KEY"] = old2
+
+
+def test_version_exported():
+    from anote_generate import __version__
+    assert __version__ == "1.0.0"


### PR DESCRIPTION
## Summary
Closes #33, #34, #35, #36

Prepares the `anote-generate` SDK for publication to PyPI.

## Changes

### `server/sdk/pyproject.toml` (new) — Closes #33
- PEP 517/518 compliant build config replacing `setup.py`
- Version `1.0.0`, Python `>=3.9`, proper PyPI classifiers
- Slim runtime deps: `requests>=2.31,<3`, `httpx>=0.24`

### `server/sdk/anote-generate/core.py` — Closes #34, #35
- `AnoteGenerate` renamed to `Anote` (backwards-compatible alias retained)
- Typed exceptions: `AnoteAuthError`, `AnoteValidationError`, `AnoteRateLimitError`, `AnoteServerError`
- Exponential backoff retry (3 attempts, 2s/4s/8s) on 5xx/network errors
- `to_dataframe()` helper (requires optional `pandas`)
- `to_file(data, path, fmt)` helper — CSV, JSONL, Parquet, JSON
- `User-Agent` header on all requests
- API key falls back to `ANOTE_API_KEY` env var

### `server/sdk/anote-generate/__init__.py`
- Exports all exception classes, `__version__ = "1.0.0"`, `__all__`

### `server/sdk/README.md` (new) — Closes #36
- PyPI-ready package README with quickstart, task type table, full usage examples

### `.github/workflows/publish.yml` (new)
- Publishes to PyPI on `v*` git tags via OIDC trusted publishing (no stored token)

### `server/sdk/tests/test_client.py` (new)
- 7 tests: success, auth error, validation error, `to_file` CSV/JSONL, missing API key, version export

## Test plan
- [ ] `pip install -e server/sdk` installs without errors
- [ ] `from anote_generate import Anote, AnoteAuthError` works
- [ ] `python -m build server/sdk` produces valid wheel + sdist
- [ ] Tag `v1.0.0` → CI publishes to PyPI (dry-run with TestPyPI first)