### PR TITLE
feat: export API (CSV/JSONL/Parquet), structured JSON logging, PII generator cleanup

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,8 +1,40 @@
-from flask import Flask, request, jsonify
+import logging
+import time
+import uuid
+
+from flask import Flask, request, jsonify, g
 from auth_utils import valid_api_key_required, extractUserEmailFromRequest, InvalidTokenError
 from api_endpoints.handler import GenerateHandler
+from logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
+
+
+@app.before_request
+def attach_request_id():
+    g.request_id = str(uuid.uuid4())
+    g.start_time = time.time()
+
+
+@app.after_request
+def log_request(response):
+    duration_ms = int((time.time() - getattr(g, 'start_time', time.time())) * 1000)
+    response.headers['X-Request-ID'] = getattr(g, 'request_id', '')
+    logger.info(
+        "Request completed",
+        extra={
+            "request_id": getattr(g, 'request_id', ''),
+            "method": request.method,
+            "path": request.path,
+            "status_code": response.status_code,
+            "duration_ms": duration_ms,
+        }
+    )
+    return response
+
 
 @app.route('/public/generate', methods=['POST'])
 # @valid_api_key_required
@@ -12,3 +44,42 @@ def generate():
     except InvalidTokenError:
         return jsonify({"error": "Invalid JWT"}), 401
     return GenerateHandler(request, user_email)
+
+
+@app.route('/public/generate/export', methods=['POST'])
+# @valid_api_key_required
+def generate_export():
+    """Generate data and return as downloadable file."""
+    from utils.export import make_export_response
+
+    try:
+        user_email = extractUserEmailFromRequest(request)
+    except InvalidTokenError as e:
+        return jsonify({"error": "Invalid JWT token", "detail": str(e)}), 401
+
+    if not request.is_json:
+        return jsonify({"error": "Content-Type must be application/json"}), 415
+
+    body = request.get_json()
+    fmt = body.pop("format", "json")
+    filename = body.pop("filename", "synthetic_data")
+
+    VALID_FORMATS = {"csv", "jsonl", "parquet", "json"}
+    if fmt not in VALID_FORMATS:
+        return jsonify({"error": f"Invalid format '{fmt}'. Must be one of: {VALID_FORMATS}"}), 422
+
+    # Build a mock request object so GenerateHandler can parse it
+    class _BodyRequest:
+        def __init__(self, body):
+            self.json = body
+
+    result = GenerateHandler(_BodyRequest(body), user_email)
+    # GenerateHandler returns a Flask Response via jsonify
+    data = result.get_json().get("data", [])
+
+    try:
+        return make_export_response(data, fmt, filename)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 422
+    except RuntimeError as e:
+        return jsonify({"error": str(e)}), 500

--- a/server/generators/PII.py
+++ b/server/generators/PII.py
@@ -1,6 +1,4 @@
 import sys
-import subprocess
-import importlib.util
 import os
 import json
 import random
@@ -8,79 +6,23 @@ import string
 import re
 import asyncio
 
-# Ensure dependencies
-REQUIRED = ["faker", "openai", "tqdm", "nest_asyncio"]
-for pkg in REQUIRED:
-    if importlib.util.find_spec(pkg) is None:
-        subprocess.run([sys.executable, "-m", "pip", "install", "-q", pkg])
-
 from faker import Faker
 from tqdm.auto import tqdm
 import nest_asyncio; nest_asyncio.apply()
 from openai import AsyncOpenAI
+from dotenv import load_dotenv
 
+load_dotenv()
 
 WORD_MIN, WORD_MAX = 40, 120
 MODEL = "gpt-4o-mini"
 TEMP = 0.9
-CONCURRENCY = 5  
+CONCURRENCY = 5
 DRY_RUN = False
 
-def ask_int(prompt_text, default):
-    while True:
-        resp = input(f"{prompt_text} [{default}]: ").strip()
-        if resp == "":
-            return default
-        if resp.isdigit() and int(resp) > 0:
-            return int(resp)
-        print("Please enter a positive integer.")
-
-def ask_float(prompt_text, default):
-    while True:
-        resp = input(f"{prompt_text} [{default}]: ").strip()
-        if resp == "":
-            return default
-        try:
-            v = float(resp)
-            if 0.0 <= v <= 1.0:
-                return v
-        except:
-            pass
-        print("Please enter a number between 0.0 and 1.0.")
-
-def ask_yesno(prompt_text, default=True):
-    default_str = "Y/n" if default else "y/N"
-    while True:
-        resp = input(f"{prompt_text} ({default_str}): ").strip().lower()
-        if resp == "":
-            return default
-        if resp in ("y", "yes"):
-            return True
-        if resp in ("n", "no"):
-            return False
-        print("Please answer yes or no.")
-
-def load_api_key():
-    key = os.environ.get("OPENAI_API_KEY")
-    if key:
-        return key.strip()
-    fallback_path = os.path.expanduser("~/.openai_key")
-    if os.path.isfile(fallback_path):
-        try:
-            with open(fallback_path, "r", encoding="utf-8") as f:
-                k = f.read().strip()
-                if k:
-                    return k
-        except Exception:
-            pass
-    return None
-
-OPENAI_KEY = load_api_key()
-if not OPENAI_KEY:
-    print("No Key")
-    DRY_RUN = True
-else:
-    os.environ.setdefault("OPENAI_API_KEY", OPENAI_KEY)
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key and not DRY_RUN:
+    raise RuntimeError("OPENAI_API_KEY environment variable is not set")
 
 client = AsyncOpenAI() if not DRY_RUN else None
 
@@ -274,8 +216,8 @@ async def maybe_preview():
     print("\nGenerated Text:\n", example["text"])
     print("\nSeed values:", example["seed"])
     print("\nEntities:", example["entities"])
-    proceed = ask_yesno("Proceed with full generation?", True)
-    if not proceed:
+    proceed = input("Proceed with full generation? (Y/n): ").strip().lower()
+    if proceed in ("n", "no"):
         print("Aborted by user.")
         sys.exit(0)
 
@@ -288,15 +230,28 @@ def generate_PII_data_sync(prompt, columns, num_rows, examples):
 
     return asyncio.run(generate_text_data(prompt, columns, num_rows, examples))
 
+
+def generate_pii_data(prompt, columns, num_rows, examples=None, params=None):
+    """Wrapper matching the standard generator contract."""
+    return generate_PII_data_sync(prompt=prompt, columns=columns, num_rows=num_rows, examples=examples or [])
+
+
 # Main entry (interactive)
 if __name__ == "__main__":
     print("Synthetic PII Text Generator Interactive")
-    N_ROWS = ask_int("How many synthetic PII examples to generate?", 100)
-    CONCURRENCY = ask_int("Maximum concurrent requests?", 10)
+    _n = input("How many synthetic PII examples to generate? [100]: ").strip()
+    N_ROWS = int(_n) if _n.isdigit() and int(_n) > 0 else 100
+    _c = input("Maximum concurrent requests? [10]: ").strip()
+    CONCURRENCY = int(_c) if _c.isdigit() and int(_c) > 0 else 10
     WORD_MIN, WORD_MAX = 40, 120
     MODEL = "gpt-4o-mini"
-    TEMP = ask_float("Temperature (0.0–1.0)?", 0.9)
-    PREVIEW = ask_yesno("Would you like to preview one example before full generation?", True)
+    _t = input("Temperature (0.0–1.0)? [0.9]: ").strip()
+    try:
+        TEMP = float(_t) if _t and 0.0 <= float(_t) <= 1.0 else 0.9
+    except ValueError:
+        TEMP = 0.9
+    _p = input("Would you like to preview one example before full generation? (Y/n): ").strip().lower()
+    PREVIEW = _p not in ("n", "no")
 
     async def main():
         if PREVIEW:

--- a/server/logging_config.py
+++ b/server/logging_config.py
@@ -1,0 +1,65 @@
+"""
+Structured JSON logging configuration for the Synthetic Data API.
+Sets up JSON-formatted log output suitable for log aggregation services.
+"""
+import os
+import logging
+import json
+import traceback
+from datetime import datetime, timezone
+
+
+class JSONFormatter(logging.Formatter):
+    """Format log records as JSON lines."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Add extra fields if present
+        for key in ("request_id", "user_email", "task_type", "duration_ms"):
+            if hasattr(record, key):
+                log_entry[key] = getattr(record, key)
+
+        # Add exception info if present
+        if record.exc_info:
+            log_entry["exception"] = {
+                "type": record.exc_info[0].__name__ if record.exc_info[0] else None,
+                "message": str(record.exc_info[1]),
+                "traceback": traceback.format_exception(*record.exc_info),
+            }
+
+        return json.dumps(log_entry, ensure_ascii=False)
+
+
+def setup_logging(level: str = None) -> None:
+    """
+    Configure JSON structured logging for the application.
+    Call once at startup before creating any loggers.
+
+    Args:
+        level: Log level string (DEBUG/INFO/WARNING/ERROR).
+               Defaults to LOG_LEVEL env var or INFO.
+    """
+    level = level or os.getenv("LOG_LEVEL", "INFO").upper()
+    numeric_level = getattr(logging, level, logging.INFO)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(numeric_level)
+
+    # Remove existing handlers
+    root_logger.handlers.clear()
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(JSONFormatter())
+    root_logger.addHandler(handler)
+
+    # Silence noisy third-party loggers
+    for noisy in ("urllib3", "requests", "httpx", "httpcore", "openai", "werkzeug"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+    logging.getLogger(__name__).info("Logging configured", extra={"level": level})

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,6 +12,7 @@ jiter==0.10.0
 numpy==2.3.1
 openai==1.93.0
 pandas==2.3.0
+pyarrow>=14.0
 pydantic==2.11.7
 pydantic_core==2.33.2
 python-dateutil==2.9.0.post0

--- a/server/utils/export.py
+++ b/server/utils/export.py
@@ -1,0 +1,85 @@
+"""
+Export utilities for converting generated data to various formats.
+Supports CSV, JSONL (OpenAI fine-tuning compatible), Parquet, and JSON.
+"""
+import csv
+import json
+import io
+from typing import List
+from flask import Response, jsonify
+
+
+def to_csv(data: List[dict]) -> str:
+    """Convert list of dicts to CSV string."""
+    if not data:
+        return ""
+    fieldnames = list(data[0].keys())
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    writer.writerows(data)
+    return output.getvalue()
+
+
+def to_jsonl(data: List[dict]) -> str:
+    """Convert list of dicts to JSONL string (one JSON object per line)."""
+    return "\n".join(json.dumps(row, ensure_ascii=False) for row in data) + "\n"
+
+
+def to_parquet_bytes(data: List[dict]) -> bytes:
+    """Convert list of dicts to Parquet bytes."""
+    try:
+        import pandas as pd
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+    except ImportError:
+        raise RuntimeError("pandas and pyarrow required for Parquet export. Run: pip install pandas pyarrow")
+    df = pd.DataFrame(data)
+    buf = io.BytesIO()
+    df.to_parquet(buf, index=False)
+    return buf.getvalue()
+
+
+def make_export_response(data: List[dict], fmt: str, filename: str = "synthetic_data") -> Response:
+    """
+    Build a Flask Response for file download.
+
+    Args:
+        data: List of row dicts
+        fmt: "csv" | "jsonl" | "parquet" | "json"
+        filename: Base filename (without extension)
+
+    Returns:
+        Flask Response with appropriate Content-Type and Content-Disposition
+    """
+    fmt = fmt.lower().strip()
+
+    if fmt == "csv":
+        content = to_csv(data)
+        return Response(
+            content,
+            mimetype="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{filename}.csv"'},
+        )
+    elif fmt == "jsonl":
+        content = to_jsonl(data)
+        return Response(
+            content,
+            mimetype="application/jsonl",
+            headers={"Content-Disposition": f'attachment; filename="{filename}.jsonl"'},
+        )
+    elif fmt == "parquet":
+        content = to_parquet_bytes(data)
+        return Response(
+            content,
+            mimetype="application/octet-stream",
+            headers={"Content-Disposition": f'attachment; filename="{filename}.parquet"'},
+        )
+    elif fmt == "json":
+        return Response(
+            json.dumps({"data": data}, indent=2, ensure_ascii=False),
+            mimetype="application/json",
+            headers={"Content-Disposition": f'attachment; filename="{filename}.json"'},
+        )
+    else:
+        raise ValueError(f"Unsupported format '{fmt}'. Must be: csv, jsonl, parquet, json")


### PR DESCRIPTION
## Summary
Closes #37, #38, #41

## Changes

### `server/utils/export.py` (new) — Closes #37
- `to_csv(data)` → CSV string
- `to_jsonl(data)` → JSONL string
- `to_parquet_bytes(data)` → Parquet bytes via `pyarrow`
- `make_export_response(data, fmt, filename)` → Flask `Response` with `Content-Disposition: attachment`
- Supports formats: `csv`, `jsonl`, `parquet`, `json`

### `server/app.py` — Closes #37
- New `POST /public/generate/export` route: accepts `format` + `filename`, runs generation, streams file download

### `server/logging_config.py` (new) — Closes #38
- `JSONFormatter` — emits one JSON line per log record with `timestamp`, `level`, `logger`, `message`, and optional `request_id`, `user_email`, `task_type`, `duration_ms`
- `setup_logging()` — configures root logger
- `@app.before_request` — attaches UUID `request_id` and `start_time` to Flask `g`
- `@app.after_request` — logs method, path, status, duration; sets `X-Request-ID` response header

### `server/generators/PII.py` — Closes #41
- Removed `subprocess.run(pip install ...)` auto-install block
- Removed `subprocess` and `importlib.util` imports
- Removed `ask_int`, `ask_float`, `ask_yesno` interactive helpers; replaced with inline `input()` calls
- Replaced `load_api_key()` (reads `~/.openai_key`) with `load_dotenv()` + `os.getenv("OPENAI_API_KEY")`
- Added `generate_pii_data(prompt, columns, num_rows, examples, params)` alias matching the standard generator contract

### `server/requirements.txt`
- Added: `pyarrow>=14.0`

## Test plan
- [ ] `POST /public/generate/export` with `format: "csv"` → downloads a `.csv` file
- [ ] `POST /public/generate/export` with `format: "parquet"` → valid Parquet file
- [ ] All log lines are valid JSON with `request_id` field
- [ ] `X-Request-ID` header present on every response
- [ ] PII generator works without `subprocess` auto-installs