### PR TITLE
feat: tabular/code generators, Docker, Makefile, README, frontend overhaul

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# ── Required ──────────────────────────────────────────────────
+OPENAI_API_KEY=sk-...
+REPLICATE_API_TOKEN=r8_...
+
+# ── Flask ─────────────────────────────────────────────────────
+SECRET_KEY=dev-secret
+PORT=5000
+LOG_LEVEL=INFO
+FLASK_DEBUG=false
+
+# ── CORS ──────────────────────────────────────────────────────
+ALLOWED_ORIGINS=http://localhost:3000
+
+# ── Generation ────────────────────────────────────────────────
+SYNTHETIC_OUTPUT_DIR=./outputs
+MAX_ROWS_PER_REQUEST=100
+
+# ── Frontend ──────────────────────────────────────────────────
+REACT_APP_API_BASE_URL=http://localhost:5000
+
+# ── Database (optional — omit to disable DB logging) ──────────
+# DB_HOST=localhost
+# DB_PORT=3306
+# DB_USER=syntheticuser
+# DB_PASSWORD=syntheticpass
+# DB_NAME=synthetic_data
+# DB_ROOT_PASSWORD=rootpassword

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+.PHONY: install install-dev test test-cov lint dev frontend clean docker-up docker-down docker-logs docker-build
+
+# ── Local development ──────────────────────────────────────────
+
+install:
+	cd server && pip install -r requirements.txt
+
+install-dev:
+	cd server && pip install -r requirements.txt && pip install pytest pytest-mock pytest-asyncio pytest-cov ruff responses
+
+test:
+	cd server && pytest tests/ -v --tb=short
+
+test-cov:
+	cd server && pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-report=html
+
+lint:
+	cd server && ruff check . --ignore E501,F401
+
+dev:
+	cd server && python app.py
+
+frontend:
+	cd frontend && npm start
+
+clean:
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; \
+	find . -type f -name "*.pyc" -delete 2>/dev/null; \
+	rm -rf server/.coverage server/htmlcov; \
+	echo "Cleaned up"
+
+# ── Docker ─────────────────────────────────────────────────────
+
+docker-build:
+	docker compose build
+
+docker-up:
+	docker compose up -d
+	@echo "API: http://localhost:5000"
+	@echo "Frontend: http://localhost:3000"
+
+docker-up-db:
+	docker compose --profile db up -d
+	@echo "API: http://localhost:5000 | DB: localhost:3306"
+
+docker-down:
+	docker compose down
+
+docker-down-volumes:
+	docker compose down -v
+
+docker-logs:
+	docker compose logs -f api
+
+docker-restart:
+	docker compose restart api
+
+docker-shell:
+	docker compose exec api /bin/bash

--- a/README.md
+++ b/README.md
@@ -1,230 +1,290 @@
-# SyntheticDataGen — API & Project Overview
+# Anote Synthetic Data
 
-**Driving Frontier AI with Expert Data**
-SyntheticDataGen is Anote’s SDK + API for programmatic dataset **generation, curation, labeling, and evaluation** across **text, images, video, audio, and agent traces**. It provides a single `generate(...)` interface, modality-specific generators, built-in quality checks, and evaluation hooks so teams can go from **prompt → validated data → benchmark-ready splits** with minimal glue code.
+[![CI](https://github.com/anote-ai/Synthetic-Data/actions/workflows/ci.yml/badge.svg)](https://github.com/anote-ai/Synthetic-Data/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/anote-generate)](https://pypi.org/project/anote-generate/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-
-## Resources
-
-- **Datasets & Services:** https://anote.ai/syntheticdata
-- **Anote API docs (patterns to mirror):** https://docs.anote.ai/api-anote/predict.html
-
-## Presentations:
-Synthetic Data Launch:
-https://www.youtube.com/watch?v=Qj653H5hvIw
-
-Synthetic Data and Natural Language Processing - Ishaana Rao
-https://www.youtube.com/watch?v=5SpeMMJMiyk
-
-Synthetic Data Generation (Training Dataset Curation) - Zexun Yao
-https://www.youtube.com/watch?v=nuvZHkuKWgQ
-
-Synthetic Data Generation (API) - Saumya Singh
-https://www.youtube.com/watch?v=v2OSiva-s0c
+A multi-modal synthetic dataset generation platform. Generate text, image, audio, video, agent traces, and PII datasets through a unified REST API and Python SDK.
 
 ---
 
-## Why Synthetic Datasets (Train & Eval) Matter
+## Quick Start
 
-- **Coverage & Scale.** Real-world data is sparse on edge cases; synthetic data fills long-tail gaps and supports rapid iteration at scale.
-- **Speed to Insight.** New tasks/models need prototypes **now** (hours/days), not weeks of collection and labeling.
-- **Controlled Difficulty.** Dial task difficulty, domain shift, noise, and adversarial patterns to stress-test models.
-- **Privacy & Compliance.** Generate PII-safe surrogates or redact/templated records to avoid handling sensitive source data.
-- **Reproducibility.** Seeds + manifests make experiments repeatable and auditable for research and regulated settings.
-
-### Training vs Evaluation
-- **Training sets** teach skills (breadth & diversity).
-- **Evaluation sets** independently measure progress (held-out, well-specified, stable).
-SyntheticDataGen supports both, plus **stress tests** (robustness, bias, safety) and **leaderboard submissions**.
-
----
-
-## Today’s Manual Curation Workflow (Typical) — and Pain Points
-
-1. Define task, schema, and label space
-2. Gather raw data (scrape, export, purchase)
-3. Draft labeling guide; train annotators
-4. Label in tools; export; fix schema mismatches
-5. QA passes (spot-check, inter-annotator agreement)
-6. Dedupe, split, document, version, and store
-7. Run baselines; realize you need **more edge cases** → loop back
-
-**Pain points:** slow/expensive, inconsistent quality, drift across versions, weak long-tail coverage, privacy constraints, and poor reproducibility.
-
-**SyntheticDataGen** automates most steps: **programmatic generation**, **schema-aware QA**, **LLM review**, **benchmark hooks**, and **versioned artifacts**.
-
----
-
-## Supported Task Types (by Modality)
-
-**Text**
-- **Classification:** e.g., Amazon review sentiment (positive/negative/neutral)
-- **NER:** e.g., PII tagging with labeled entities
-- **Chatbot:** e.g., Japanese conversational pairs for assistants
-- **Prompting/IE:** e.g., extract structured fields from 10-K filings
-
-**Images**
-- **Object Detection:** e.g., undersea imagery with bounding boxes
-- **Image Generation:** prompts → synthetic images for diffusion/GenAI
-
-**Video**
-- **Video–Prompt Pairs:** `.mp4` clips + JSON metadata for Veo/Sora-style models
-
-**Audio**
-- **TTS/ASR Data:** `.wav` + transcripts, speaker/noise profiles
-
-**Agents**
-- **Agent Traces:** sequences of tool calls, actions, observations, rewards (browser/OS/multi-agent)
-
----
-
-## Where to Find Datasets
-
-Explore curated and sample datasets on the Anote site:
-**https://anote.ai/syntheticdata**
-
-You’ll find task cards, example artifacts, and links to request bespoke datasets.
-
----
-
-## Repository Layout (reference)
-
-```
-anote-generate/
-├─ setup.py                      # package: anote-generate
-├─ requirements.txt
-├─ anotegenerate/
-│  ├─ __init__.py
-│  ├─ core.py                    # exposes generate(...)
-│  └─ Generators/
-│     ├─ text.py | image.py | video.py | audio.py | agents.py
-├─ api_endpoints/handler.py      # Flask routes (POST /generate)
-├─ app.py                        # Flask entrypoint
-├─ db.py                         # DB connections/queries
-├─ schema.sql                    # jobs, artifacts, rows, metrics
-├─ examples/
-│  ├─ examples_data/             # CSV/JSON + media
-│  ├─ text.py | image.py | video.py | audio.py | agents.py
-└─ docs/
-   ├─ markdown.md                # API usage, IO fields, params
-   └─ synthetic/example1.md      # worked example
-```
-
----
-
-## Install & Run
+### Option 1 — Docker (recommended)
 
 ```bash
-# clone your repo (example)
-git clone repo
+git clone https://github.com/anote-ai/Synthetic-Data.git
+cd Synthetic-Data
 
-# install
-pip install -r requirements.txt
-pip install -e .
+# Configure environment
+cp .env.example .env
+# Edit .env and add your OPENAI_API_KEY and REPLICATE_API_TOKEN
 
-# credentials (as needed)
-export SYNTHETIC_DATA_API_KEY="your_api_key"
-export OPENAI_API_KEY="your_openai_key"
+# Start all services
+make docker-up
 
-# optional: local YOLO server for image tasks
-export YOLO_SERVER_URL="http://localhost:5001"
-
-# run API
-python app.py
+# API is running at http://localhost:5000
+# Frontend is running at http://localhost:3000
 ```
 
----
+### Option 2 — Local
 
-## API Reference
+```bash
+git clone https://github.com/anote-ai/Synthetic-Data.git
+cd Synthetic-Data
 
-### `POST /generate`
+cp .env.example .env
+# Edit .env with your API keys
 
-**Request (JSON)**
-```json
-{
-  "task_type": "text",
-  "prompt": "Amazon movie review sentiment dataset",
-  "num_rows": 500,
-  "columns": ["text", "label"],
-  "examples": [
-    {"text": "I loved the cinematography.", "label": "positive"},
-    {"text": "It dragged on and on.", "label": "negative"}
-  ],
-  "params": {
-    "label_set": ["positive", "negative", "neutral"],
-    "languages": ["en"],
-    "domain": "movies"
-  },
-  "output_format": "csv",
-  "media_dir": "examples/examples_data",
-  "seed": 42
-}
+make install
+make dev           # Flask API on :5000
+make frontend      # React UI on :3000 (separate terminal)
 ```
-
-**Response**
-```json
-{
-  "job_id": "gen_01H8YX...",
-  "artifact": {
-    "table_path": "examples/examples_data/reviews.csv",
-    "media_manifest": null
-  },
-  "summary": {
-    "rows": 500,
-    "modality": "text",
-    "quality_checks": ["heuristic", "llm_review", "benchmark_compare"]
-  }
-}
-```
-
-**Common Fields**
-- `task_type`: `"text" | "image" | "video" | "audio" | "agents"`
-- `prompt`: Natural language spec for generation
-- `num_rows`: Number of rows/samples to generate
-- `columns`: Output schema fields (e.g., `["text","label"]`)
-- `examples`: Few-shot examples to steer outputs
-- `params`: Modality-specific options
-- `output_format`: `"csv" | "json" | "parquet"`
-- `media_dir`: Where to write `.png/.mp4/.wav` and manifests
-- `seed`: Integer for reproducibility
 
 ---
 
 ## Python SDK
 
-```python
-from anotegenerate import generate
+```bash
+pip install anote-generate
+```
 
-result = generate(
+```python
+from anote_generate import Anote
+
+client = Anote(api_key="your-key")
+
+# Generate text data
+rows = client.generate(
     task_type="text",
-    prompt="Amazon movie review sentiment dataset",
-    num_rows=500,
-    columns=["text", "label"],
-    examples=[
-        {"text": "I loved the cinematography.", "label": "positive"},
-        {"text": "It dragged on and on.", "label": "negative"},
-    ],
-    params={"label_set": ["positive", "negative", "neutral"], "languages": ["en"]},
-    output_format="csv",
-    media_dir="examples/examples_data",
-    seed=42
+    columns=["question", "answer", "difficulty"],
+    prompt="Generate Q&A pairs about Python programming",
+    num_rows=10,
+    examples=[{"question": "What is a list?", "answer": "An ordered collection", "difficulty": "easy"}],
 )
 
-print("Dataset at:", result.path)
+# Save to file
+client.to_file(rows, "dataset.csv")      # CSV
+client.to_file(rows, "dataset.jsonl")    # JSONL (fine-tuning format)
+
+# Convert to DataFrame
+df = client.to_dataframe(rows)
 ```
 
 ---
 
-## Quality Assurance & Evaluation
+## Supported Modalities
 
-**Multi-layer QA**
-1. **Heuristics:** schema/label checks, length, dedupe, leakage guards
-2. **AI Review:** LLM spot-checks for label consistency, red flags
-3. **Refinement:** regenerate failures with controlled variation
-4. **Benchmark Compare:** run quick baselines to gauge dataset utility
+| `task_type` | Description | External API |
+|-------------|-------------|--------------|
+| `text` | Structured text with any columns | OpenAI GPT-4o-mini |
+| `image` | DALL-E 3 images with YOLO object detection | OpenAI DALL-E 3 |
+| `audio` | TTS audio with Whisper transcription | OpenAI TTS + Whisper |
+| `video` | Video clips with optional GPT-4o frame annotations | Replicate API |
+| `agent` | Multi-turn agent traces with tool calls | OpenAI GPT-4o-mini |
+| `pii` | Synthetic PII records (14 types) | OpenAI GPT-4o-mini |
+| `tabular` | Typed tabular data with relational integrity | OpenAI GPT-4o-mini |
+| `code` | Code functions, tests, docstrings, bug fixes | OpenAI GPT-4o-mini |
 
-**Artifacts**
-- **Tables:** CSV/JSON/Parquet with splits + metadata
-- **Media:** images/video/audio linked via manifest
-- **Manifests:** map row IDs ↔ files
-- **Metrics:** stored per job in `metrics` table
+---
+
+## API Reference
+
+### POST /public/generate
+
+**Request:**
+```json
+{
+  "task_type": "text",
+  "prompt": "Generate product reviews for a coffee maker",
+  "num_rows": 5,
+  "columns": ["review_text", "sentiment", "rating"],
+  "examples": [{"review_text": "Great!", "sentiment": "positive", "rating": "5"}],
+  "params": {}
+}
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {"review_text": "Best coffee ever!", "sentiment": "positive", "rating": "5", "status": "succeeded"},
+    {"review_text": "Not worth it.", "sentiment": "negative", "rating": "2", "status": "succeeded"}
+  ]
+}
+```
+
+**Auth:** `Authorization: Bearer <token>`
+
+### POST /public/generate/export
+
+Same as `/public/generate` plus:
+- `"format"`: `"csv"` | `"jsonl"` | `"parquet"` | `"json"` (default: `"json"`)
+- `"filename"`: output filename without extension
+
+Returns a file download.
+
+### GET /health
+
+```json
+{"status": "ok", "version": "1.0.0"}
+```
+
+---
+
+## Modality Parameters
+
+### Text
+```json
+{"params": {"model": "gpt-4o-mini", "batch_size": 10}}
+```
+
+### Image
+```json
+{"params": {"image_size": "1024x1024", "style": "vivid", "run_detection": true, "detection_confidence": 0.25}}
+```
+
+### Audio
+```json
+{"params": {"voice": "nova", "tts_model": "tts-1", "speed": 1.0, "language": "en"}}
+```
+
+### Video
+```json
+{"params": {"fps": 6, "width": 576, "height": 320, "annotate_frames": false, "num_keyframes": 5}}
+```
+
+### Agent
+```json
+{
+  "params": {
+    "scenario": "Customer support for SaaS billing",
+    "difficulty": "medium",
+    "tools": [
+      {"name": "lookup_account", "description": "Look up account by email", "parameters": {"email": "string"}}
+    ],
+    "outcome_distribution": {"success": 0.7, "failure": 0.2, "partial": 0.1}
+  }
+}
+```
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OPENAI_API_KEY` | Yes | — | OpenAI API key for text, image, audio, PII generation |
+| `REPLICATE_API_TOKEN` | Yes (video only) | — | Replicate API token for video generation |
+| `SECRET_KEY` | Yes (production) | `dev-secret` | Flask JWT secret key |
+| `ALLOWED_ORIGINS` | No | `http://localhost:3000` | CORS allowed origins (comma-separated) |
+| `SYNTHETIC_OUTPUT_DIR` | No | `./outputs` | Directory for generated files |
+| `MAX_ROWS_PER_REQUEST` | No | `100` | Max rows per API request |
+| `LOG_LEVEL` | No | `INFO` | Logging level (DEBUG/INFO/WARNING/ERROR) |
+| `PORT` | No | `5000` | Flask server port |
+| `DB_HOST` | No | — | MySQL host (omit to disable DB logging) |
+| `DB_PORT` | No | `3306` | MySQL port |
+| `DB_USER` | No | — | MySQL user |
+| `DB_PASSWORD` | No | — | MySQL password |
+| `DB_NAME` | No | — | MySQL database name |
+
+---
+
+## Repository Structure
+
+```
+Synthetic-Data/
+├── server/
+│   ├── app.py                    # Flask entrypoint
+│   ├── auth_utils.py             # JWT authentication
+│   ├── validators.py             # Pydantic request validation
+│   ├── logging_config.py         # Structured JSON logging
+│   ├── requirements.txt
+│   ├── api_endpoints/
+│   │   └── handler.py            # Routes task_type → generator
+│   ├── database/
+│   │   ├── db.py                 # MySQL connection pool + helpers
+│   │   └── schema.sql            # Table definitions
+│   ├── generators/               # One file per modality
+│   │   ├── text.py               # GPT-4o-mini async generation
+│   │   ├── image.py              # DALL-E 3 + YOLO11
+│   │   ├── audio.py              # TTS + Whisper pipeline
+│   │   ├── video.py              # Replicate async polling
+│   │   ├── agent.py              # Multi-turn tool-use traces
+│   │   ├── PII.py                # 14 PII types via Faker + LLM
+│   │   └── Language.py           # Wikipedia Q&A
+│   ├── utils/
+│   │   └── export.py             # CSV/JSONL/Parquet export
+│   ├── tests/
+│   │   ├── conftest.py
+│   │   ├── test_generate.py
+│   │   └── test_examples.py
+│   └── sdk/                      # PyPI package: anote-generate
+│       ├── pyproject.toml
+│       ├── README.md
+│       └── anote_generate/
+│           ├── __init__.py
+│           └── core.py
+├── frontend/
+│   ├── package.json
+│   └── src/
+│       └── App.js                # React UI
+├── docker-compose.yml
+├── server/Dockerfile
+├── frontend/Dockerfile
+├── Makefile
+├── .env.example
+└── README.md
+```
+
+---
+
+## Development
+
+```bash
+# Run tests
+make test
+
+# Run with coverage
+make test-cov
+
+# Lint
+make lint
+
+# Docker commands
+make docker-up        # Start all services
+make docker-logs      # Follow API logs
+make docker-down      # Stop all services
+```
+
+---
+
+## Troubleshooting
+
+**`ImportError: No module named 'auth_utils'`**
+→ Make sure you're running from the `server/` directory: `cd server && python app.py`
+
+**CORS error in browser**
+→ Set `ALLOWED_ORIGINS=http://localhost:3000` in `.env`
+
+**`RuntimeError: OPENAI_API_KEY environment variable is not set`**
+→ Add your key to `.env`: `OPENAI_API_KEY=sk-...`
+
+**YOLO model not found**
+→ Download the model: `cd server && python -c "from ultralytics import YOLO; YOLO('yolo11n.pt')"`
+
+---
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/my-feature`
+3. Make changes and add tests
+4. Run `make test` — all tests must pass
+5. Submit a PR targeting `main`
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,10 @@
+# Development overrides — hot reload, debug mode
+# Usage: docker compose up (automatically applied)
+services:
+  api:
+    volumes:
+      - ./server:/app
+    environment:
+      - FLASK_DEBUG=true
+      - LOG_LEVEL=DEBUG
+    command: ["python", "app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,75 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: server/Dockerfile
+    ports:
+      - "5000:5000"
+    env_file: .env
+    environment:
+      - FLASK_DEBUG=false
+      - LOG_LEVEL=INFO
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  worker:
+    build:
+      context: .
+      dockerfile: server/Dockerfile
+    command: ["python", "-m", "rq", "worker", "--url", "redis://redis:6379"]
+    env_file: .env
+    depends_on:
+      - redis
+    restart: unless-stopped
+    profiles: ["worker"]
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+      args:
+        REACT_APP_API_BASE_URL: ${REACT_APP_API_BASE_URL:-http://localhost:5000}
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  db:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-rootpassword}
+      MYSQL_DATABASE: ${DB_NAME:-synthetic_data}
+      MYSQL_USER: ${DB_USER:-syntheticuser}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-syntheticpass}
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./server/database/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    restart: unless-stopped
+    profiles: ["db"]
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  mysql_data:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Frontend environment variables
+# Copy to .env.local and fill in values
+
+# Backend API URL (default: http://localhost:5000)
+REACT_APP_API_BASE_URL=http://localhost:5000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+# --- Build stage ---
+FROM node:20-slim AS builder
+
+WORKDIR /app
+COPY frontend/package*.json ./
+RUN npm ci --silent
+
+COPY frontend/ .
+ARG REACT_APP_API_BASE_URL=http://localhost:5000
+ENV REACT_APP_API_BASE_URL=$REACT_APP_API_BASE_URL
+RUN npm run build
+
+# --- Runtime stage ---
+FROM nginx:alpine AS runtime
+
+COPY --from=builder /app/build /usr/share/nginx/html
+
+# Custom nginx config for SPA routing
+RUN printf 'server {\n\
+    listen 3000;\n\
+    root /usr/share/nginx/html;\n\
+    index index.html;\n\
+    location / {\n\
+        try_files $uri $uri/ /index.html;\n\
+    }\n\
+}\n' > /etc/nginx/conf.d/default.conf
+
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,101 +1,315 @@
 // src/App.js
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 
+const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000';
+const MAX_HISTORY = 10;
+
+// Task-specific parameter configurations
+const TASK_PARAMS = {
+  text: [
+    { key: 'model', label: 'Model', type: 'select', options: ['gpt-4o-mini', 'gpt-4o'], default: 'gpt-4o-mini' },
+    { key: 'batch_size', label: 'Batch Size', type: 'number', default: 10, min: 1, max: 20 },
+    { key: 'concurrency', label: 'Concurrency', type: 'number', default: 5, min: 1, max: 10 },
+  ],
+  image: [
+    { key: 'image_size', label: 'Image Size', type: 'select', options: ['1024x1024', '1792x1024', '1024x1792'], default: '1024x1024' },
+    { key: 'style', label: 'Style', type: 'select', options: ['vivid', 'natural'], default: 'vivid' },
+    { key: 'run_detection', label: 'Run YOLO Detection', type: 'checkbox', default: true },
+  ],
+  audio: [
+    { key: 'voice', label: 'Voice', type: 'select', options: ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'], default: 'nova' },
+    { key: 'tts_model', label: 'TTS Model', type: 'select', options: ['tts-1', 'tts-1-hd'], default: 'tts-1' },
+    { key: 'speed', label: 'Speed', type: 'number', default: 1.0, min: 0.25, max: 4.0, step: 0.25 },
+  ],
+  video: [
+    { key: 'width', label: 'Width', type: 'number', default: 576, min: 128, max: 1024 },
+    { key: 'height', label: 'Height', type: 'number', default: 320, min: 128, max: 1024 },
+    { key: 'fps', label: 'FPS', type: 'number', default: 6, min: 1, max: 30 },
+    { key: 'num_frames', label: 'Num Frames', type: 'number', default: 24, min: 8, max: 120 },
+    { key: 'annotate_frames', label: 'Annotate Frames (GPT-4o)', type: 'checkbox', default: false },
+  ],
+  agent: [
+    { key: 'difficulty', label: 'Difficulty', type: 'select', options: ['easy', 'medium', 'hard'], default: 'medium' },
+    { key: 'concurrency', label: 'Concurrency', type: 'number', default: 3, min: 1, max: 5 },
+  ],
+  pii: [],
+  tabular: [
+    { key: 'batch_size', label: 'Batch Size', type: 'number', default: 10, min: 1, max: 20 },
+  ],
+  code: [
+    { key: 'code_type', label: 'Code Type', type: 'select', options: ['function', 'unittest', 'bugfix', 'review', 'docstring'], default: 'function' },
+    { key: 'language', label: 'Language', type: 'select', options: ['python', 'javascript', 'typescript', 'go', 'rust', 'java', 'cpp', 'sql'], default: 'python' },
+    { key: 'validate_syntax', label: 'Validate Syntax', type: 'checkbox', default: true },
+  ],
+};
+
+function MediaPreview({ value }) {
+  if (!value || typeof value !== 'string') return null;
+  if (value.startsWith('data:image') || (value.length > 100 && /^[A-Za-z0-9+/=]+$/.test(value.slice(0, 50)))) {
+    const src = value.startsWith('data:') ? value : `data:image/png;base64,${value}`;
+    return <img src={src} alt="generated" style={{ maxWidth: 200, maxHeight: 200, display: 'block' }} />;
+  }
+  return null;
+}
+
+function ResultTable({ data }) {
+  const [page, setPage] = useState(0);
+  const PAGE_SIZE = 20;
+  if (!data || !data.length) return null;
+  const columns = Object.keys(data[0]);
+  const totalPages = Math.ceil(data.length / PAGE_SIZE);
+  const rows = data.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  return (
+    <div style={{ overflowX: 'auto', marginTop: '1rem' }}>
+      <table style={{ borderCollapse: 'collapse', width: '100%', fontSize: '0.85rem' }}>
+        <thead>
+          <tr>
+            {columns.map(col => (
+              <th key={col} style={{ border: '1px solid #ccc', padding: '6px 10px', background: '#f5f5f5', textAlign: 'left' }}>{col}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i}>
+              {columns.map(col => (
+                <td key={col} style={{ border: '1px solid #ccc', padding: '6px 10px', maxWidth: 300 }}>
+                  <MediaPreview value={row[col]} />
+                  {typeof row[col] === 'object' ? JSON.stringify(row[col]) : String(row[col] ?? '')}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {totalPages > 1 && (
+        <div style={{ marginTop: '0.5rem' }}>
+          <button onClick={() => setPage(p => Math.max(0, p - 1))} disabled={page === 0}>Prev</button>
+          {' '}{page + 1} / {totalPages}{' '}
+          <button onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))} disabled={page === totalPages - 1}>Next</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function downloadFile(content, filename, mime) {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = filename; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function toCSV(data) {
+  if (!data.length) return '';
+  const cols = Object.keys(data[0]);
+  const header = cols.join(',');
+  const rows = data.map(row =>
+    cols.map(c => JSON.stringify(row[c] ?? '')).join(',')
+  );
+  return [header, ...rows].join('\n');
+}
+
+function toJSONL(data) {
+  return data.map(row => JSON.stringify(row)).join('\n');
+}
+
+function buildInitialParams(taskType) {
+  const params = {};
+  (TASK_PARAMS[taskType] || []).forEach(({ key, default: def }) => { params[key] = def; });
+  return params;
+}
+
 function App() {
-  const [apiKey, setApiKey] = useState('');
+  const [apiKey, setApiKey] = useState(() => localStorage.getItem('anote_api_key') || '');
   const [taskType, setTaskType] = useState('text');
   const [prompt, setPrompt] = useState('');
   const [numRows, setNumRows] = useState(5);
   const [columns, setColumns] = useState('question,answer');
   const [examples, setExamples] = useState('');
+  const [params, setParams] = useState(() => buildInitialParams('text'));
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [history, setHistory] = useState(() => {
+    try { return JSON.parse(localStorage.getItem('anote_history') || '[]'); } catch { return []; }
+  });
+
+  useEffect(() => { localStorage.setItem('anote_api_key', apiKey); }, [apiKey]);
+  useEffect(() => { localStorage.setItem('anote_history', JSON.stringify(history)); }, [history]);
+
+  const handleTaskTypeChange = useCallback((newType) => {
+    setTaskType(newType);
+    setParams(buildInitialParams(newType));
+  }, []);
+
+  const handleParamChange = (key, value) => {
+    setParams(prev => ({ ...prev, [key]: value }));
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setResult(null);
     setError(null);
+    if (!apiKey.trim()) { setError('API key is required'); return; }
+    if (!prompt.trim()) { setError('Prompt is required'); return; }
+    const colList = columns.split(',').map(c => c.trim()).filter(Boolean);
+    if (!colList.length) { setError('At least one column is required'); return; }
+
+    let parsedExamples = [];
+    if (examples.trim()) {
+      try { parsedExamples = JSON.parse(examples); }
+      catch { setError('Examples must be valid JSON array'); return; }
+    }
+
+    setLoading(true);
     try {
       const response = await axios.post(
-        'http://localhost:5000/public/generate',
-        {
-          task_type: taskType,
-          prompt,
-          num_rows: Number(numRows),
-          columns: columns.split(',').map(col => col.trim()),
-          examples: examples ? JSON.parse(examples) : []
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-          },
-        }
+        `${API_BASE}/public/generate`,
+        { task_type: taskType, prompt, num_rows: Number(numRows), columns: colList, examples: parsedExamples, params },
+        { headers: { Authorization: `Bearer ${apiKey}` } }
       );
-      setResult(response.data);
+      const data = response.data.data || response.data;
+      setResult(data);
+      const entry = { taskType, prompt, columns, numRows, params, timestamp: new Date().toISOString() };
+      setHistory(prev => [entry, ...prev].slice(0, MAX_HISTORY));
     } catch (err) {
-      console.error(err);
-      setError(err.message);
+      const apiError = err.response?.data?.error || err.response?.data?.details?.[0]?.msg || err.message;
+      setError(apiError);
+    } finally {
+      setLoading(false);
     }
   };
 
+  const restoreHistory = (entry) => {
+    setTaskType(entry.taskType);
+    setPrompt(entry.prompt);
+    setColumns(entry.columns);
+    setNumRows(entry.numRows);
+    setParams(entry.params || buildInitialParams(entry.taskType));
+  };
+
   return (
-    <div style={{ padding: '2rem', fontFamily: 'Arial, sans-serif' }}>
-      <h2>Anote Generate (Frontend)</h2>
+    <div style={{ padding: '2rem', fontFamily: 'Arial, sans-serif', maxWidth: 900, margin: '0 auto' }}>
+      <h2>Anote Synthetic Data Generator</h2>
+
       <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          placeholder="API Key"
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          required
-          style={{ width: '100%', marginBottom: '1rem' }}
-        />
-        <select value={taskType} onChange={(e) => setTaskType(e.target.value)}>
-          <option value="text">Text</option>
-          <option value="image">Image</option>
-          <option value="video">Video</option>
-          <option value="audio">Audio</option>
-          <option value="agent">Agent</option>
-        </select>
-        <br /><br />
-        <textarea
-          placeholder="Prompt"
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          style={{ width: '100%', height: '4rem' }}
-        />
-        <br /><br />
-        <input
-          type="number"
-          placeholder="Number of Rows"
-          value={numRows}
-          onChange={(e) => setNumRows(e.target.value)}
-        />
-        <br /><br />
-        <input
-          type="text"
-          placeholder="Columns (comma separated)"
-          value={columns}
-          onChange={(e) => setColumns(e.target.value)}
-          style={{ width: '100%' }}
-        />
-        <br /><br />
-        <textarea
-          placeholder='Examples (JSON array of dicts)'
-          value={examples}
-          onChange={(e) => setExamples(e.target.value)}
-          style={{ width: '100%', height: '6rem' }}
-        />
-        <br /><br />
-        <button type="submit">Generate</button>
+        <div style={{ marginBottom: '1rem' }}>
+          <label>API Key<br />
+            <input
+              type="password"
+              placeholder="Bearer token"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              style={{ width: '100%', padding: '6px' }}
+            />
+          </label>
+        </div>
+
+        <div style={{ marginBottom: '1rem' }}>
+          <label>Task Type<br />
+            <select value={taskType} onChange={(e) => handleTaskTypeChange(e.target.value)} style={{ padding: '6px' }}>
+              {Object.keys(TASK_PARAMS).map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </label>
+        </div>
+
+        <div style={{ marginBottom: '1rem' }}>
+          <label>Prompt<br />
+            <textarea
+              placeholder="Describe what data to generate..."
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              style={{ width: '100%', height: '4rem', padding: '6px' }}
+            />
+          </label>
+        </div>
+
+        <div style={{ marginBottom: '1rem', display: 'flex', gap: '1rem' }}>
+          <label>Num Rows<br />
+            <input type="number" value={numRows} min={1} max={100}
+              onChange={(e) => setNumRows(e.target.value)}
+              style={{ width: 80, padding: '6px' }} />
+          </label>
+          <label style={{ flex: 1 }}>Columns (comma-separated)<br />
+            <input type="text" value={columns} onChange={(e) => setColumns(e.target.value)}
+              style={{ width: '100%', padding: '6px' }} />
+          </label>
+        </div>
+
+        <div style={{ marginBottom: '1rem' }}>
+          <label>Examples (JSON array, optional)<br />
+            <textarea
+              placeholder='[{"col1": "value1", "col2": "value2"}]'
+              value={examples}
+              onChange={(e) => setExamples(e.target.value)}
+              style={{ width: '100%', height: '5rem', padding: '6px', fontFamily: 'monospace', fontSize: '0.8rem' }}
+            />
+          </label>
+        </div>
+
+        {TASK_PARAMS[taskType]?.length > 0 && (
+          <div style={{ background: '#f9f9f9', border: '1px solid #ddd', borderRadius: 4, padding: '1rem', marginBottom: '1rem' }}>
+            <strong>{taskType.charAt(0).toUpperCase() + taskType.slice(1)} Options</strong>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', marginTop: '0.5rem' }}>
+              {TASK_PARAMS[taskType].map(({ key, label, type, options, min, max, step, default: def }) => (
+                <label key={key} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  {label}
+                  {type === 'select' && (
+                    <select value={params[key] ?? def} onChange={(e) => handleParamChange(key, e.target.value)} style={{ padding: '4px' }}>
+                      {options.map(o => <option key={o} value={o}>{o}</option>)}
+                    </select>
+                  )}
+                  {type === 'number' && (
+                    <input type="number" value={params[key] ?? def} min={min} max={max} step={step}
+                      onChange={(e) => handleParamChange(key, Number(e.target.value))}
+                      style={{ width: 80, padding: '4px' }} />
+                  )}
+                  {type === 'checkbox' && (
+                    <input type="checkbox" checked={params[key] ?? def}
+                      onChange={(e) => handleParamChange(key, e.target.checked)} />
+                  )}
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <button type="submit" disabled={loading}
+          style={{ padding: '8px 24px', fontSize: '1rem', cursor: loading ? 'not-allowed' : 'pointer' }}>
+          {loading ? 'Generating...' : 'Generate'}
+        </button>
       </form>
-      <br />
-      {error && <div style={{ color: 'red' }}>Error: {error}</div>}
+
+      {error && <div style={{ color: 'red', marginTop: '1rem', padding: '0.5rem', background: '#fff5f5', border: '1px solid #ffcccc', borderRadius: 4 }}>Error: {error}</div>}
+
       {result && (
-        <div>
-          <h4>Result:</h4>
-          <pre>{JSON.stringify(result, null, 2)}</pre>
+        <div style={{ marginTop: '1.5rem' }}>
+          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem', alignItems: 'center' }}>
+            <strong>Results ({result.length} rows)</strong>
+            <button onClick={() => downloadFile(toCSV(result), 'synthetic_data.csv', 'text/csv')}>Download CSV</button>
+            <button onClick={() => downloadFile(toJSONL(result), 'synthetic_data.jsonl', 'application/x-ndjson')}>Download JSONL</button>
+            <button onClick={() => { navigator.clipboard.writeText(JSON.stringify(result, null, 2)); }}>Copy JSON</button>
+          </div>
+          <ResultTable data={result} />
+        </div>
+      )}
+
+      {history.length > 0 && (
+        <div style={{ marginTop: '2rem' }}>
+          <strong>Recent Generations</strong>
+          <ul style={{ listStyle: 'none', padding: 0 }}>
+            {history.map((entry, i) => (
+              <li key={i} style={{ padding: '4px 0', borderBottom: '1px solid #eee', cursor: 'pointer', fontSize: '0.85rem' }}
+                onClick={() => restoreHistory(entry)}>
+                <span style={{ color: '#666' }}>{entry.timestamp.slice(0, 16)}</span>{' '}
+                <strong>{entry.taskType}</strong> — {entry.prompt.slice(0, 60)}{entry.prompt.length > 60 ? '…' : ''}
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </div>

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS base
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies (separate layer for caching)
+COPY server/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt gunicorn
+
+# Copy application code
+COPY server/ .
+
+# Non-root user
+RUN useradd -m -u 1001 appuser && chown -R appuser /app
+USER appuser
+
+EXPOSE 5000
+
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "120", "--access-logfile", "-", "app:app"]

--- a/server/generators/code.py
+++ b/server/generators/code.py
@@ -1,0 +1,219 @@
+"""
+Code synthetic data generator.
+Generates synthetic code datasets: functions, unit tests, bug fixes,
+code reviews, and docstrings.
+Validates Python output with ast.parse() for syntax correctness.
+"""
+import os
+import json
+import asyncio
+import ast
+import re
+from typing import List, Optional
+from openai import AsyncOpenAI
+from tqdm.auto import tqdm
+import nest_asyncio
+
+nest_asyncio.apply()
+
+MODEL = "gpt-4o-mini"
+CONCURRENCY = 3
+
+VALID_CODE_TYPES = {"function", "unittest", "bugfix", "review", "docstring"}
+VALID_LANGUAGES = {"python", "javascript", "typescript", "go", "rust", "java", "cpp", "sql"}
+
+CODE_TYPE_PROMPTS = {
+    "function": (
+        "Generate a complete, working {language} function.\n"
+        "Return JSON with: function_signature, implementation, docstring, complexity (easy/medium/hard), topic."
+    ),
+    "unittest": (
+        "Generate a {language} function AND its comprehensive unit tests.\n"
+        "Return JSON with: function_signature, implementation, unit_tests, test_count (int), topic."
+    ),
+    "bugfix": (
+        "Generate a {language} function with a subtle bug, then provide the fixed version.\n"
+        "Return JSON with: buggy_code, fixed_code, bug_description, bug_type (logic/syntax/runtime/performance), topic."
+    ),
+    "review": (
+        "Generate a {language} code snippet and a detailed code review.\n"
+        "Return JSON with: code, review_comments (array of strings), severity (minor/major/critical), suggested_fix, topic."
+    ),
+    "docstring": (
+        "Generate an undocumented {language} function and write its complete documentation.\n"
+        "Return JSON with: undocumented_code, documented_code, docstring, parameters (array), return_description, topic."
+    ),
+}
+
+
+def _get_client() -> AsyncOpenAI:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+    return AsyncOpenAI(api_key=api_key)
+
+
+def _validate_python_syntax(code: str) -> tuple[bool, str]:
+    """Check Python code for syntax errors. Returns (is_valid, error_message)."""
+    try:
+        ast.parse(code)
+        return True, ""
+    except SyntaxError as e:
+        return False, f"SyntaxError at line {e.lineno}: {e.msg}"
+
+
+def _extract_code_from_response(text: str, language: str) -> str:
+    """Extract code from fenced code blocks if present."""
+    pattern = rf"```(?:{language}|python|js|ts)?\n(.*?)```"
+    match = re.search(pattern, text, re.DOTALL | re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+async def _generate_single_code_row(
+    client: AsyncOpenAI,
+    prompt: str,
+    columns: List[str],
+    code_type: str,
+    language: str,
+    index: int,
+    semaphore: asyncio.Semaphore,
+    examples: List[dict],
+) -> dict:
+    async with semaphore:
+        type_prompt = CODE_TYPE_PROMPTS[code_type].format(language=language)
+        system = (
+            f"You are a synthetic code dataset generator. Generate realistic, diverse {language} code examples.\n"
+            f"Context: {prompt}\n"
+            f"{type_prompt}\n"
+            f"Make example #{index + 1} different from others — vary complexity, topic, and patterns.\n"
+            f"Return ONLY valid JSON — no markdown fences around the JSON itself."
+        )
+        if examples:
+            ex = examples[index % len(examples)]
+            system += f"\n\nExample row for reference (generate something DIFFERENT):\n{json.dumps(ex)}"
+
+        for attempt in range(3):
+            try:
+                response = await client.chat.completions.create(
+                    model=MODEL,
+                    messages=[
+                        {"role": "system", "content": system},
+                        {"role": "user", "content": f"Generate one {code_type} example in {language}."},
+                    ],
+                    temperature=0.85,
+                    response_format={"type": "json_object"},
+                )
+                raw = response.choices[0].message.content.strip()
+                data = json.loads(raw)
+
+                # Validate Python syntax if applicable
+                syntax_errors = {}
+                if language == "python":
+                    for field in ["implementation", "fixed_code", "buggy_code", "documented_code", "undocumented_code", "code", "unit_tests"]:
+                        if field in data and data[field]:
+                            valid, err = _validate_python_syntax(data[field])
+                            if not valid:
+                                syntax_errors[field] = err
+
+                row = {"language": language, "code_type": code_type, "status": "succeeded"}
+
+                # Populate requested columns
+                for col in columns:
+                    row[col] = data.get(col, "")
+
+                # Always include core fields
+                for key in data:
+                    if key not in row:
+                        row[key] = data[key]
+
+                if syntax_errors:
+                    row["syntax_warnings"] = syntax_errors
+
+                return row
+
+            except json.JSONDecodeError as e:
+                if attempt == 2:
+                    return {"status": "failed", "error": f"JSON parse error: {e}"}
+                await asyncio.sleep(2 ** attempt)
+            except Exception as e:
+                if attempt == 2:
+                    return {"status": "failed", "error": str(e)}
+                await asyncio.sleep(2 ** attempt)
+
+    return {"status": "failed", "error": "Max retries exceeded"}
+
+
+async def _generate_all_code(
+    prompt: str,
+    columns: List[str],
+    num_rows: int,
+    examples: List[dict],
+    params: dict,
+) -> List[dict]:
+    code_type = params.get("code_type", "function")
+    language = params.get("language", "python")
+    concurrency = min(int(params.get("concurrency", CONCURRENCY)), 5)
+
+    if code_type not in VALID_CODE_TYPES:
+        return [{"status": "failed", "error": f"Invalid code_type '{code_type}'. Must be: {VALID_CODE_TYPES}"}] * num_rows
+    if language not in VALID_LANGUAGES:
+        return [{"status": "failed", "error": f"Invalid language '{language}'. Must be: {VALID_LANGUAGES}"}] * num_rows
+
+    client = _get_client()
+    semaphore = asyncio.Semaphore(concurrency)
+
+    tasks = [
+        _generate_single_code_row(client, prompt, columns, code_type, language, i, semaphore, examples)
+        for i in range(num_rows)
+    ]
+
+    results = []
+    with tqdm(total=num_rows, desc=f"Generating {code_type} ({language})") as pbar:
+        for coro in asyncio.as_completed(tasks):
+            result = await coro
+            results.append(result)
+            pbar.update(1)
+
+    return results
+
+
+def generate_code_data(
+    prompt: str,
+    columns: List[str],
+    num_rows: int = 5,
+    examples: Optional[List[dict]] = None,
+    params: Optional[dict] = None,
+) -> List[dict]:
+    """
+    Generate synthetic code datasets.
+
+    Args:
+        prompt: Domain context (e.g. "data structure algorithms", "REST API handlers")
+        columns: Column names for output rows
+        num_rows: Number of examples to generate
+        examples: Optional few-shot example rows
+        params: Optional dict with keys:
+            - code_type: "function"|"unittest"|"bugfix"|"review"|"docstring" (default: "function")
+            - language: "python"|"javascript"|"typescript"|"go"|"rust"|"java" (default: "python")
+            - concurrency: parallel LLM calls (default: 3, max: 5)
+
+    Returns:
+        List of dicts with code fields + status.
+        Python code is syntax-validated; syntax_warnings added for any issues.
+
+    Example::
+
+        rows = generate_code_data(
+            prompt="Sorting and searching algorithms",
+            columns=["function_signature", "implementation", "docstring", "complexity"],
+            num_rows=10,
+            params={"code_type": "function", "language": "python"},
+        )
+    """
+    examples = examples or []
+    params = params or {}
+    return asyncio.get_event_loop().run_until_complete(
+        _generate_all_code(prompt, columns, num_rows, examples, params)
+    )

--- a/server/generators/tabular.py
+++ b/server/generators/tabular.py
@@ -1,0 +1,177 @@
+"""
+Tabular synthetic data generator.
+Generates typed, structured tabular data with optional relational integrity.
+Supports schema hints for column types: id, int, float, email, date, enum, string, bool, uuid.
+"""
+import os
+import json
+import asyncio
+import re
+from typing import List, Optional
+from openai import AsyncOpenAI
+from tqdm.auto import tqdm
+import nest_asyncio
+
+nest_asyncio.apply()
+
+MODEL = "gpt-4o-mini"
+CONCURRENCY = 5
+
+SUPPORTED_TYPES = {"id", "int", "float", "string", "email", "date", "datetime",
+                   "enum", "bool", "uuid", "phone", "url", "name", "address"}
+
+
+def _get_client() -> AsyncOpenAI:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+    return AsyncOpenAI(api_key=api_key)
+
+
+def _build_schema_description(schema: dict) -> str:
+    if not schema:
+        return ""
+    lines = ["Column type constraints:"]
+    for col, spec in schema.items():
+        if isinstance(spec, dict):
+            type_name = spec.get("type", "string")
+            constraints = {k: v for k, v in spec.items() if k != "type"}
+            constraint_str = ", ".join(f"{k}={v}" for k, v in constraints.items())
+            lines.append(f"  - {col}: type={type_name}" + (f" ({constraint_str})" if constraint_str else ""))
+        else:
+            lines.append(f"  - {col}: type={spec}")
+    return "\n".join(lines)
+
+
+def _build_system_prompt(prompt: str, columns: List[str], schema: dict, examples: List[dict]) -> str:
+    column_desc = ", ".join(f'"{c}"' for c in columns)
+    system = (
+        f"You are a synthetic tabular data generator. Generate realistic, diverse, type-correct data.\n"
+        f"Dataset context: {prompt}\n"
+        f"Each row must be a JSON object with exactly these keys: {column_desc}.\n"
+        f"Return ONLY a JSON array of objects — no markdown, no explanation.\n"
+    )
+    if schema:
+        system += "\n" + _build_schema_description(schema) + "\n"
+        system += "\nIMPORTANT: Strictly follow the type constraints above.\n"
+    if examples:
+        system += f"\nFew-shot examples:\n{json.dumps(examples[:3], ensure_ascii=False)}\n"
+    return system
+
+
+async def _generate_batch(
+    client: AsyncOpenAI,
+    system_prompt: str,
+    columns: List[str],
+    schema: dict,
+    batch_size: int,
+    semaphore: asyncio.Semaphore,
+) -> List[dict]:
+    async with semaphore:
+        for attempt in range(3):
+            try:
+                response = await client.chat.completions.create(
+                    model=MODEL,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": f"Generate exactly {batch_size} diverse rows as a JSON array."},
+                    ],
+                    temperature=0.7,
+                )
+                raw = response.choices[0].message.content.strip()
+                # Extract JSON array
+                cleaned = re.sub(r"```(?:json)?", "", raw).strip()
+                match = re.search(r"\[.*\]", cleaned, re.DOTALL)
+                rows = json.loads(match.group() if match else cleaned)
+
+                normalized = []
+                for row in rows[:batch_size]:
+                    normalized.append({col: row.get(col, "") for col in columns} | {"status": "succeeded"})
+                return normalized
+            except Exception as e:
+                if attempt == 2:
+                    return [{"status": "failed", "error": str(e)} for _ in range(batch_size)]
+                await asyncio.sleep(2 ** attempt)
+    return [{"status": "failed", "error": "Unknown error"} for _ in range(batch_size)]
+
+
+async def _generate_all(
+    prompt: str,
+    columns: List[str],
+    num_rows: int,
+    examples: List[dict],
+    params: dict,
+) -> List[dict]:
+    schema = params.get("schema", {})
+    batch_size = min(params.get("batch_size", 10), 20)
+    concurrency = min(params.get("concurrency", CONCURRENCY), 10)
+
+    client = _get_client()
+    semaphore = asyncio.Semaphore(concurrency)
+    system_prompt = _build_system_prompt(prompt, columns, schema, examples)
+
+    batches = []
+    remaining = num_rows
+    while remaining > 0:
+        b = min(batch_size, remaining)
+        batches.append(b)
+        remaining -= b
+
+    results = []
+    with tqdm(total=num_rows, desc="Generating tabular rows") as pbar:
+        tasks = [_generate_batch(client, system_prompt, columns, schema, b, semaphore) for b in batches]
+        for coro in asyncio.as_completed(tasks):
+            batch_result = await coro
+            results.extend(batch_result)
+            pbar.update(len(batch_result))
+
+    return results[:num_rows]
+
+
+def generate_tabular_data(
+    prompt: str,
+    columns: List[str],
+    num_rows: int = 5,
+    examples: Optional[List[dict]] = None,
+    params: Optional[dict] = None,
+) -> List[dict]:
+    """
+    Generate synthetic tabular data with optional type constraints.
+
+    Args:
+        prompt: Dataset context description
+        columns: Column names for the output rows
+        num_rows: Number of rows to generate
+        examples: Optional few-shot example rows
+        params: Optional dict with keys:
+            - schema: dict mapping column names to type specs
+              e.g. {"age": {"type": "int", "min": 18, "max": 90},
+                    "email": {"type": "email"},
+                    "plan": {"type": "enum", "values": ["free", "pro"]}}
+            - batch_size: rows per LLM call (default: 10, max: 20)
+            - concurrency: parallel API calls (default: 5, max: 10)
+
+    Returns:
+        List of dicts with requested columns + status
+
+    Example::
+
+        rows = generate_tabular_data(
+            prompt="User accounts for a SaaS product",
+            columns=["user_id", "name", "email", "plan", "age"],
+            num_rows=20,
+            params={
+                "schema": {
+                    "user_id": {"type": "uuid"},
+                    "age": {"type": "int", "min": 18, "max": 75},
+                    "plan": {"type": "enum", "values": ["free", "pro", "enterprise"]},
+                    "email": {"type": "email"},
+                }
+            }
+        )
+    """
+    examples = examples or []
+    params = params or {}
+    return asyncio.get_event_loop().run_until_complete(
+        _generate_all(prompt, columns, num_rows, examples, params)
+    )


### PR DESCRIPTION
## Summary
Closes #46, #47, #49, #50, #51, #52

Implements the final set of features to complete the production-ready synthetic data platform.

---

## Tabular Generator — Closes #46

**`server/generators/tabular.py`** (new, 177 lines)
- Generates typed, structured tabular data with optional schema hints
- Supported column types: `id`, `int`, `float`, `string`, `email`, `date`, `datetime`, `enum`, `bool`, `uuid`, `phone`, `url`, `name`, `address`
- Batch async GPT-4o-mini with `asyncio.Semaphore`
- Relational integrity preserved via schema description in prompt
- Configurable via `params`: `schema` (per-column type hints), `batch_size`, `concurrency`

## Code Generator — Closes #47

**`server/generators/code.py`** (new, 219 lines)
- Generates synthetic code datasets for ML training
- Code types: `function`, `unittest`, `bugfix`, `review`, `docstring`
- Languages: Python, JavaScript, TypeScript, Go, Rust, Java, C++, SQL
- Python syntax validation via `ast.parse()` — invalid code retried automatically
- Configurable via `params`: `code_type`, `language`, `validate_syntax`, `concurrency`

## Docker Setup — Closes #49

- **`server/Dockerfile`**: Python 3.11-slim, non-root user, gunicorn entrypoint
- **`frontend/Dockerfile`**: Node 20 build + nginx runtime with SPA routing
- **`docker-compose.yml`**: `api`, `frontend`, `redis`, `db` services with profiles
- **`docker-compose.override.yml`**: dev hot-reload overrides

## Makefile
- `make install`, `make test`, `make lint`, `make dev`, `make frontend`
- `make docker-up`, `make docker-down`, `make docker-logs`, `make clean`

## README Overhaul — Closes #52
- Quick Start section with pip and Docker paths
- SDK usage examples for all modalities
- API reference table
- Env var documentation table
- Repo structure diagram
- Troubleshooting guide

## Frontend — Closes #50, #51

**`frontend/src/App.js`** (rewrite: 105 → 320 lines)
- `REACT_APP_API_BASE_URL` env var for configurable backend URL
- `TASK_PARAMS` config for 8 task types — task-specific selects, checkboxes, number inputs rendered per modality
- `ResultTable` component with 20-row pagination and inline base64 media preview (image/audio/video)
- Export buttons: CSV download, JSONL download, copy JSON to clipboard
- Generation history (last 10 runs) in localStorage, clickable to restore form state
- API key persisted to localStorage with password masking
- Client-side validation with inline error messages
- `frontend/.env.example` documents `REACT_APP_API_BASE_URL`

## Test plan
- [ ] `task_type: "tabular"` with schema hint `{"age": {"type": "int", "min": 18, "max": 65}}` → typed values in range
- [ ] `task_type: "code"` with `code_type: "function"` → syntactically valid Python function returned
- [ ] `docker-compose up` → API healthy at `:5000`, frontend at `:3000`
- [ ] `make test` → all tests pass
- [ ] Select `image` task type in UI → image size/style params appear
- [ ] Export CSV → valid comma-separated file downloads