### PR TITLE
feat: CORS, tabular generator, code generator, quality scoring (#31, #44, #46, #47)

### DIFF
--- a/server/api_endpoints/handler.py
+++ b/server/api_endpoints/handler.py
@@ -13,6 +13,8 @@ _GENERATOR_REGISTRY = {
     "agent":    ("generators.agent",    "generate_agent_data"),
     "pii":      ("generators.PII",      "generate_pii_data"),
     "language": ("generators.Language", "generate_language_data"),
+    "tabular":  ("generators.tabular",  "generate_tabular_data"),
+    "code":     ("generators.code",     "generate_code_data"),
 }
 
 

--- a/server/app.py
+++ b/server/app.py
@@ -4,6 +4,7 @@ import time
 import uuid
 
 from flask import Flask, request, jsonify, g
+from flask_cors import CORS
 from auth_utils import valid_api_key_required, extractUserEmailFromRequest, InvalidTokenError
 from api_endpoints.handler import GenerateHandler
 from logging_config import setup_logging
@@ -12,6 +13,12 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
+CORS(
+    app,
+    origins=os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(","),
+    methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
+)
 
 VALID_TASK_TYPES = {"text", "image", "video", "audio", "agent", "pii", "language", "tabular", "code"}
 MAX_ROWS = int(os.getenv("MAX_ROWS_PER_REQUEST", "100"))
@@ -117,3 +124,37 @@ def generate_export():
         return jsonify({"error": str(e)}), 422
     except RuntimeError as e:
         return jsonify({"error": str(e)}), 500
+
+
+@app.route("/public/generate/quality", methods=["POST"])
+def generate_quality():
+    from utils.quality import score_dataset
+
+    if not request.is_json:
+        return jsonify({"error": "Content-Type must be application/json"}), 415
+
+    try:
+        extractUserEmailFromRequest(request)
+    except InvalidTokenError as e:
+        return jsonify({"error": "Invalid JWT token", "detail": str(e)}), 401
+
+    body = request.get_json() or {}
+    data = body.get("data", [])
+    prompt = body.get("prompt", "")
+    run_llm_review = body.get("run_llm_review", False)
+    deduplicate = body.get("deduplicate", False)
+
+    if not isinstance(data, list) or not data:
+        return jsonify({"error": "data must be a non-empty list"}), 422
+
+    try:
+        report = score_dataset(data, prompt=prompt, run_llm_review=run_llm_review)
+    except Exception as e:
+        logger.error("Quality scoring failed: %s", e, exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+    response = {"quality": report}
+    if deduplicate:
+        from utils.quality import deduplicate as dedup_fn
+        response["data"] = dedup_fn(data)
+    return jsonify(response)

--- a/server/generators/code.py
+++ b/server/generators/code.py
@@ -1,0 +1,189 @@
+"""
+Code synthetic data generator.
+Generates synthetic code datasets for ML training using GPT-4o-mini.
+Supports functions, unit tests, bug-fix pairs, review comments, and docstrings.
+"""
+import ast
+import os
+import json
+import asyncio
+import re
+from typing import List, Optional
+import openai
+import nest_asyncio
+
+nest_asyncio.apply()
+
+MODEL = "gpt-4o-mini"
+CONCURRENCY = 3
+MAX_RETRIES = 3
+
+VALID_CODE_TYPES = {"function", "unittest", "bugfix", "review", "docstring"}
+VALID_LANGUAGES = {"python", "javascript", "typescript", "go", "rust", "java", "cpp", "sql"}
+
+
+def _get_client():
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+    return openai.AsyncOpenAI(api_key=api_key)
+
+
+def _build_system_prompt(code_type: str, language: str, columns: List[str], prompt: str) -> str:
+    col_desc = ", ".join(f'"{c}"' for c in columns)
+    type_instructions = {
+        "function": (
+            "Generate a function with: signature, full implementation, and a brief docstring. "
+            'Return a JSON object with keys: "function_signature", "implementation", "docstring", plus any other requested columns.'
+        ),
+        "unittest": (
+            "Generate a function implementation and its corresponding unit tests. "
+            'Return a JSON object with keys: "function_code", "test_code", "test_description", plus any other requested columns.'
+        ),
+        "bugfix": (
+            "Generate a snippet of buggy code and its corrected version with an explanation. "
+            'Return a JSON object with keys: "buggy_code", "fixed_code", "bug_description", "fix_explanation", plus any other requested columns.'
+        ),
+        "review": (
+            "Generate a code snippet and realistic code review comments pointing out improvements. "
+            'Return a JSON object with keys: "code_snippet", "review_comments", "severity", plus any other requested columns.'
+        ),
+        "docstring": (
+            "Generate an undocumented function and a high-quality docstring for it. "
+            'Return a JSON object with keys: "undocumented_code", "docstring", plus any other requested columns.'
+        ),
+    }
+    return (
+        f"You are a synthetic code dataset generator. Generate realistic {language} code examples.\n"
+        f"Task context: {prompt}\n"
+        f"Code type: {code_type}. {type_instructions.get(code_type, '')}\n"
+        f"The output must include these fields: {col_desc}.\n"
+        f"Return ONLY valid JSON — no markdown fences, no explanation.\n"
+    )
+
+
+def _validate_python(code: str) -> bool:
+    try:
+        ast.parse(code)
+        return True
+    except SyntaxError:
+        return False
+
+
+def _extract_code_from_json(raw: str) -> dict:
+    cleaned = re.sub(r"```(?:json)?", "", raw).strip()
+    cleaned = re.sub(r"```$", "", cleaned).strip()
+    return json.loads(cleaned)
+
+
+async def _generate_single(
+    client,
+    system_prompt: str,
+    columns: List[str],
+    code_type: str,
+    language: str,
+    validate_syntax: bool,
+    semaphore: asyncio.Semaphore,
+    index: int,
+) -> dict:
+    async with semaphore:
+        for attempt in range(MAX_RETRIES):
+            try:
+                response = await client.chat.completions.create(
+                    model=MODEL,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": f"Generate a unique {code_type} example (item {index + 1})."},
+                    ],
+                    temperature=0.85,
+                    response_format={"type": "json_object"},
+                )
+                raw = response.choices[0].message.content.strip()
+                parsed = _extract_code_from_json(raw)
+
+                # Python syntax validation
+                if validate_syntax and language == "python":
+                    for key in ("implementation", "function_code", "buggy_code", "fixed_code",
+                                "undocumented_code", "code_snippet"):
+                        if key in parsed and not _validate_python(parsed[key]):
+                            if attempt < MAX_RETRIES - 1:
+                                await asyncio.sleep(2 ** attempt)
+                                continue
+                            return {"status": "failed", "error": f"Generated {key} has invalid Python syntax"}
+
+                row = {col: parsed.get(col, "") for col in columns}
+                row["status"] = "succeeded"
+                row["language"] = language
+                row["code_type"] = code_type
+                return row
+
+            except json.JSONDecodeError as e:
+                if attempt == MAX_RETRIES - 1:
+                    return {"status": "failed", "error": f"JSON parse error: {e}"}
+                await asyncio.sleep(2 ** attempt)
+            except Exception as e:
+                if attempt == MAX_RETRIES - 1:
+                    return {"status": "failed", "error": str(e)}
+                await asyncio.sleep(2 ** attempt)
+    return {"status": "failed", "error": "Max retries exceeded"}
+
+
+async def _generate_all(
+    prompt: str,
+    columns: List[str],
+    num_rows: int,
+    examples: List[dict],
+    params: dict,
+) -> List[dict]:
+    code_type = params.get("code_type", "function")
+    language = params.get("language", "python")
+    validate_syntax = params.get("validate_syntax", True)
+    concurrency = min(int(params.get("concurrency", CONCURRENCY)), 8)
+
+    if code_type not in VALID_CODE_TYPES:
+        return [
+            {"status": "failed", "error": f"Invalid code_type '{code_type}'. Must be one of: {VALID_CODE_TYPES}"}
+        ] * num_rows
+
+    if language not in VALID_LANGUAGES:
+        return [
+            {"status": "failed", "error": f"Invalid language '{language}'. Must be one of: {VALID_LANGUAGES}"}
+        ] * num_rows
+
+    client = _get_client()
+    semaphore = asyncio.Semaphore(concurrency)
+    system_prompt = _build_system_prompt(code_type, language, columns, prompt)
+
+    tasks = [
+        _generate_single(client, system_prompt, columns, code_type, language, validate_syntax, semaphore, i)
+        for i in range(num_rows)
+    ]
+
+    results = []
+    for coro in asyncio.as_completed(tasks):
+        results.append(await coro)
+
+    return results[:num_rows]
+
+
+def generate_code_data(
+    prompt: str,
+    columns: List[str],
+    num_rows: int = 5,
+    examples: Optional[List[dict]] = None,
+    params: Optional[dict] = None,
+) -> List[dict]:
+    """
+    Generate synthetic code datasets.
+
+    params keys:
+        code_type: "function" | "unittest" | "bugfix" | "review" | "docstring" (default: "function")
+        language: "python" | "javascript" | "typescript" | "go" | "rust" | "java" | "cpp" | "sql"
+        validate_syntax: bool — validate Python syntax (default: True)
+        concurrency: parallel API calls (default: 3, max: 8)
+    """
+    examples = examples or []
+    params = params or {}
+    return asyncio.get_event_loop().run_until_complete(
+        _generate_all(prompt, columns, num_rows, examples, params)
+    )

--- a/server/generators/tabular.py
+++ b/server/generators/tabular.py
@@ -1,0 +1,146 @@
+"""
+Tabular synthetic data generator.
+Generates typed, structured tabular data using GPT-4o-mini with optional schema hints.
+"""
+import os
+import json
+import asyncio
+import re
+from typing import List, Optional
+import openai
+import nest_asyncio
+
+nest_asyncio.apply()
+
+MODEL = "gpt-4o-mini"
+CONCURRENCY = 5
+MAX_RETRIES = 3
+
+SUPPORTED_TYPES = {
+    "id", "int", "float", "string", "email", "date", "datetime",
+    "enum", "bool", "uuid", "phone", "url", "name", "address",
+}
+
+
+def _get_client():
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+    return openai.AsyncOpenAI(api_key=api_key)
+
+
+def _build_system_prompt(columns: List[str], prompt: str, schema: dict, examples: List[dict]) -> str:
+    column_desc = ", ".join(f'"{c}"' for c in columns)
+    schema_hints = ""
+    if schema:
+        hints = []
+        for col, hint in schema.items():
+            col_type = hint.get("type", "string")
+            extras = {k: v for k, v in hint.items() if k != "type"}
+            hints.append(f'  "{col}": type={col_type}' + (f", {extras}" if extras else ""))
+        schema_hints = "\nColumn type hints:\n" + "\n".join(hints)
+
+    system = (
+        f"You are a synthetic tabular data generator. Generate realistic, diverse, typed data rows.\n"
+        f"Context: {prompt}\n"
+        f"Each row must be a JSON object with exactly these keys: {column_desc}.{schema_hints}\n"
+        f"Respect the column types strictly. Return ONLY a JSON array — no markdown, no explanation.\n"
+    )
+    if examples:
+        system += f"\nReference examples:\n{json.dumps(examples[:3], ensure_ascii=False)}\n"
+    return system
+
+
+def _extract_json(raw: str) -> list:
+    cleaned = re.sub(r"```(?:json)?", "", raw).strip()
+    match = re.search(r"\[.*\]", cleaned, re.DOTALL)
+    if match:
+        return json.loads(match.group())
+    return json.loads(cleaned)
+
+
+async def _generate_batch(
+    client,
+    system_prompt: str,
+    columns: List[str],
+    batch_size: int,
+    semaphore: asyncio.Semaphore,
+) -> List[dict]:
+    async with semaphore:
+        for attempt in range(MAX_RETRIES):
+            try:
+                response = await client.chat.completions.create(
+                    model=MODEL,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": f"Generate exactly {batch_size} diverse rows. Return a JSON array."},
+                    ],
+                    temperature=0.8,
+                )
+                raw = response.choices[0].message.content.strip()
+                rows = _extract_json(raw)
+                return [
+                    {col: row.get(col, "") for col in columns} | {"status": "succeeded"}
+                    for row in rows[:batch_size]
+                ]
+            except json.JSONDecodeError as e:
+                if attempt == MAX_RETRIES - 1:
+                    return [{"status": "failed", "error": f"JSON parse error: {e}"} for _ in range(batch_size)]
+                await asyncio.sleep(2 ** attempt)
+            except Exception as e:
+                if attempt == MAX_RETRIES - 1:
+                    return [{"status": "failed", "error": str(e)} for _ in range(batch_size)]
+                await asyncio.sleep(2 ** attempt)
+    return [{"status": "failed", "error": "Unknown error"} for _ in range(batch_size)]
+
+
+async def _generate_all(
+    prompt: str,
+    columns: List[str],
+    num_rows: int,
+    examples: List[dict],
+    params: dict,
+) -> List[dict]:
+    schema = params.get("schema", {})
+    batch_size = min(params.get("batch_size", 10), 20)
+    concurrency = min(params.get("concurrency", CONCURRENCY), 10)
+
+    client = _get_client()
+    semaphore = asyncio.Semaphore(concurrency)
+    system_prompt = _build_system_prompt(columns, prompt, schema, examples)
+
+    batches = []
+    remaining = num_rows
+    while remaining > 0:
+        b = min(batch_size, remaining)
+        batches.append(b)
+        remaining -= b
+
+    tasks = [_generate_batch(client, system_prompt, columns, b, semaphore) for b in batches]
+    results = []
+    for coro in asyncio.as_completed(tasks):
+        results.extend(await coro)
+
+    return results[:num_rows]
+
+
+def generate_tabular_data(
+    prompt: str,
+    columns: List[str],
+    num_rows: int = 5,
+    examples: Optional[List[dict]] = None,
+    params: Optional[dict] = None,
+) -> List[dict]:
+    """
+    Generate synthetic tabular data with optional column type hints.
+
+    params keys:
+        schema: dict mapping column name → {"type": ..., "min": ..., "max": ..., "values": [...]}
+        batch_size: rows per LLM call (default 10, max 20)
+        concurrency: parallel calls (default 5, max 10)
+    """
+    examples = examples or []
+    params = params or {}
+    return asyncio.get_event_loop().run_until_complete(
+        _generate_all(prompt, columns, num_rows, examples, params)
+    )

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,6 +5,7 @@ colorama==0.4.6
 distro==1.9.0
 faker>=24.0.0
 flask>=3.0.0
+flask-cors>=4.0.0
 flask-limiter>=3.5.0
 h11==0.16.0
 httpcore==1.0.9

--- a/server/tests/test_coverage.py
+++ b/server/tests/test_coverage.py
@@ -202,14 +202,15 @@ class TestExportEndpoint:
 # ─────────────────────────────────────────────────────────────────────────────
 
 class TestHandlerEdgeCases:
-    def test_task_type_in_app_but_not_registry_returns_422(self, client):
-        """'tabular' passes app.py validation but is not in _GENERATOR_REGISTRY."""
-        resp = client.post("/public/generate", json={
-            "task_type": "tabular",
-            "prompt": "Generate data",
-            "num_rows": 1,
-            "columns": ["col"],
-        })
+    def test_unresolvable_generator_returns_422(self, client):
+        """When _resolve_generator returns None the handler responds 422."""
+        with patch("api_endpoints.handler._resolve_generator", return_value=None):
+            resp = client.post("/public/generate", json={
+                "task_type": "text",
+                "prompt": "Generate data",
+                "num_rows": 1,
+                "columns": ["col"],
+            })
         assert resp.status_code == 422
         assert "error" in resp.get_json()
 

--- a/server/tests/test_new_features.py
+++ b/server/tests/test_new_features.py
@@ -1,0 +1,325 @@
+"""Tests for CORS, tabular generator, code generator, and quality scoring."""
+import json
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("OPENAI_API_KEY", "test-key-sk-1234")
+os.environ.setdefault("REPLICATE_API_TOKEN", "test-replicate-token")
+os.environ.setdefault("SYNTHETIC_OUTPUT_DIR", "/tmp/synthetic-test-output")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CORS (#31)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCORS:
+    def test_cors_header_present_on_health(self, client):
+        resp = client.get("/health", headers={"Origin": "http://localhost:3000"})
+        assert resp.status_code == 200
+        assert "Access-Control-Allow-Origin" in resp.headers
+
+    def test_options_preflight_allowed(self, client):
+        resp = client.options(
+            "/public/generate",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "Content-Type,Authorization",
+            },
+        )
+        assert resp.status_code in (200, 204)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tabular generator (#46)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestTabularGenerator:
+    def test_generate_tabular_mocked_via_endpoint(self, client):
+        mock_result = [
+            {"user_id": "uuid-001", "name": "Alice", "age": "30", "status": "succeeded"},
+            {"user_id": "uuid-002", "name": "Bob", "age": "25", "status": "succeeded"},
+        ]
+        with patch("generators.tabular.generate_tabular_data", return_value=mock_result):
+            resp = client.post("/public/generate", json={
+                "task_type": "tabular",
+                "prompt": "Generate user profile data",
+                "num_rows": 2,
+                "columns": ["user_id", "name", "age"],
+                "params": {"schema": {"age": {"type": "int", "min": 18, "max": 90}}},
+            })
+        assert resp.status_code == 200
+        data = resp.get_json()["data"]
+        assert len(data) == 2
+        assert all(r["status"] == "succeeded" for r in data)
+
+    def test_build_system_prompt_with_schema(self):
+        from generators.tabular import _build_system_prompt
+        schema = {"age": {"type": "int", "min": 18, "max": 90}, "email": {"type": "email"}}
+        prompt = _build_system_prompt(["age", "email"], "user data", schema, [])
+        assert "age" in prompt
+        assert "int" in prompt
+        assert "email" in prompt
+
+    def test_build_system_prompt_with_examples(self):
+        from generators.tabular import _build_system_prompt
+        examples = [{"age": "25", "email": "test@example.com"}]
+        prompt = _build_system_prompt(["age", "email"], "user data", {}, examples)
+        assert "test@example.com" in prompt
+
+    def test_invalid_openai_key_raises(self):
+        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}):
+            from generators.tabular import _get_client
+            with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+                _get_client()
+
+    def test_generate_tabular_with_mocked_api(self):
+        from generators.tabular import generate_tabular_data
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock(message=MagicMock(content=json.dumps([
+            {"name": "Alice", "age": "28", "email": "alice@test.com"},
+            {"name": "Bob", "age": "35", "email": "bob@test.com"},
+        ])))]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+
+        with patch("generators.tabular.openai.AsyncOpenAI", return_value=mock_client):
+            results = generate_tabular_data(
+                "Generate user data",
+                ["name", "age", "email"],
+                2,
+                [],
+                {"schema": {"age": {"type": "int"}}},
+            )
+
+        assert len(results) == 2
+        assert results[0]["status"] == "succeeded"
+        assert results[0]["name"] == "Alice"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Code generator (#47)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCodeGenerator:
+    def test_generate_code_mocked_via_endpoint(self, client):
+        mock_result = [{
+            "function_signature": "def add(a: int, b: int) -> int:",
+            "implementation": "def add(a, b):\n    return a + b",
+            "docstring": "Add two integers.",
+            "status": "succeeded",
+        }]
+        with patch("generators.code.generate_code_data", return_value=mock_result):
+            resp = client.post("/public/generate", json={
+                "task_type": "code",
+                "prompt": "Python utility functions",
+                "num_rows": 1,
+                "columns": ["function_signature", "implementation", "docstring"],
+                "params": {"code_type": "function", "language": "python"},
+            })
+        assert resp.status_code == 200
+        data = resp.get_json()["data"]
+        assert data[0]["status"] == "succeeded"
+
+    def test_invalid_code_type_returns_failed(self):
+        from generators.code import generate_code_data
+        results = generate_code_data("test", ["code"], 1, [], {"code_type": "invalid_type"})
+        assert results[0]["status"] == "failed"
+        assert "code_type" in results[0]["error"].lower()
+
+    def test_invalid_language_returns_failed(self):
+        from generators.code import generate_code_data
+        results = generate_code_data("test", ["code"], 1, [], {"language": "brainfuck"})
+        assert results[0]["status"] == "failed"
+        assert "language" in results[0]["error"].lower()
+
+    def test_python_syntax_validation_valid(self):
+        from generators.code import _validate_python
+        assert _validate_python("def add(a, b):\n    return a + b") is True
+
+    def test_python_syntax_validation_invalid(self):
+        from generators.code import _validate_python
+        assert _validate_python("def add(a, b)\n    return a + b") is False
+
+    def test_build_system_prompt_contains_code_type(self):
+        from generators.code import _build_system_prompt
+        prompt = _build_system_prompt("function", "python", ["implementation", "docstring"], "math utils")
+        assert "function" in prompt
+        assert "python" in prompt
+        assert "math utils" in prompt
+
+    def test_generate_code_with_mocked_api(self):
+        from generators.code import generate_code_data
+
+        code_json = json.dumps({
+            "function_signature": "def multiply(a: int, b: int) -> int:",
+            "implementation": "def multiply(a, b):\n    return a * b",
+            "docstring": "Multiply two integers.",
+        })
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock(message=MagicMock(content=code_json))]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+
+        with patch("generators.code.openai.AsyncOpenAI", return_value=mock_client):
+            results = generate_code_data(
+                "Python math utilities",
+                ["function_signature", "implementation", "docstring"],
+                1,
+                [],
+                {"code_type": "function", "language": "python", "validate_syntax": False},
+            )
+
+        assert len(results) == 1
+        assert results[0]["status"] == "succeeded"
+        assert "multiply" in results[0]["function_signature"]
+
+    def test_bugfix_code_type_via_mocked_api(self):
+        from generators.code import generate_code_data
+
+        bugfix_json = json.dumps({
+            "buggy_code": "def add(a, b):\n    return a - b",
+            "fixed_code": "def add(a, b):\n    return a + b",
+            "bug_description": "Wrong operator used",
+            "fix_explanation": "Changed - to +",
+        })
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock(message=MagicMock(content=bugfix_json))]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+
+        with patch("generators.code.openai.AsyncOpenAI", return_value=mock_client):
+            results = generate_code_data(
+                "Python bug fixes",
+                ["buggy_code", "fixed_code", "bug_description"],
+                1,
+                [],
+                {"code_type": "bugfix", "language": "python", "validate_syntax": False},
+            )
+
+        assert results[0]["status"] == "succeeded"
+        assert results[0]["buggy_code"] == "def add(a, b):\n    return a - b"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Quality scoring (#44)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestQualityUtils:
+    ROWS = [
+        {"name": "Alice", "score": "95"},
+        {"name": "Bob", "score": "82"},
+        {"name": "Alice", "score": "95"},  # duplicate of first
+        {"name": "Carol", "score": ""},    # incomplete score
+    ]
+
+    def test_deduplicate_removes_exact_duplicates(self):
+        from utils.quality import deduplicate
+        result = deduplicate(self.ROWS)
+        assert len(result) == 3
+        names = [r["name"] for r in result]
+        assert names.count("Alice") == 1
+
+    def test_deduplicate_empty_list(self):
+        from utils.quality import deduplicate
+        assert deduplicate([]) == []
+
+    def test_score_completeness_all_filled(self):
+        from utils.quality import score_completeness
+        rows = [{"name": "Alice", "age": "30"}, {"name": "Bob", "age": "25"}]
+        scores = score_completeness(rows)
+        assert scores["name"] == 1.0
+        assert scores["age"] == 1.0
+
+    def test_score_completeness_with_empty_values(self):
+        from utils.quality import score_completeness
+        scores = score_completeness(self.ROWS)
+        assert scores["name"] == 1.0
+        assert scores["score"] < 1.0
+
+    def test_score_completeness_empty_data(self):
+        from utils.quality import score_completeness
+        assert score_completeness([]) == {}
+
+    def test_score_dataset_basic(self):
+        from utils.quality import score_dataset
+        report = score_dataset(self.ROWS)
+        assert report["total_rows"] == 4
+        assert report["unique_rows"] == 3
+        assert report["duplicates_removed"] == 1
+        assert "completeness" in report
+        assert "avg_completeness" in report
+        assert "llm_review" not in report
+
+    def test_score_dataset_with_llm_review_mocked(self):
+        from utils.quality import score_dataset
+        mock_review = {"score": 8, "issues": [], "suggestions": ["Add more diversity"]}
+        with patch("utils.quality.llm_coherence_review", return_value=mock_review):
+            report = score_dataset(self.ROWS, prompt="user data", run_llm_review=True)
+        assert "llm_review" in report
+        assert report["llm_review"]["score"] == 8
+
+    def test_score_dataset_llm_review_error_handled(self):
+        from utils.quality import score_dataset
+        with patch("utils.quality.llm_coherence_review", side_effect=RuntimeError("API down")):
+            report = score_dataset(self.ROWS, prompt="test", run_llm_review=True)
+        assert "error" in report["llm_review"]
+
+
+class TestQualityEndpoint:
+    ROWS = [
+        {"name": "Alice", "score": "95"},
+        {"name": "Bob", "score": "82"},
+    ]
+
+    def test_quality_basic(self, client):
+        resp = client.post("/public/generate/quality", json={"data": self.ROWS})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "quality" in body
+        assert body["quality"]["total_rows"] == 2
+
+    def test_quality_with_deduplication(self, client):
+        rows_with_dup = self.ROWS + [self.ROWS[0]]  # one duplicate
+        resp = client.post("/public/generate/quality", json={
+            "data": rows_with_dup,
+            "deduplicate": True,
+        })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "data" in body  # deduplicated data returned
+        assert len(body["data"]) == 2
+
+    def test_quality_with_llm_review_mocked(self, client):
+        mock_review = {"score": 9, "issues": [], "suggestions": []}
+        with patch("utils.quality.llm_coherence_review", return_value=mock_review):
+            resp = client.post("/public/generate/quality", json={
+                "data": self.ROWS,
+                "prompt": "user data",
+                "run_llm_review": True,
+            })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["quality"]["llm_review"]["score"] == 9
+
+    def test_quality_empty_data_returns_422(self, client):
+        resp = client.post("/public/generate/quality", json={"data": []})
+        assert resp.status_code == 422
+
+    def test_quality_missing_data_field_returns_422(self, client):
+        resp = client.post("/public/generate/quality", json={"prompt": "test"})
+        assert resp.status_code == 422
+
+    def test_quality_non_json_returns_415(self, client):
+        resp = client.post("/public/generate/quality", data="not json", content_type="text/plain")
+        assert resp.status_code == 415
+
+    def test_quality_401_on_bad_auth(self, client):
+        from auth_utils import InvalidTokenError
+        with patch("app.extractUserEmailFromRequest", side_effect=InvalidTokenError("no")):
+            resp = client.post("/public/generate/quality", json={"data": self.ROWS})
+        assert resp.status_code == 401

--- a/server/utils/quality.py
+++ b/server/utils/quality.py
@@ -1,0 +1,100 @@
+"""Data quality utilities: deduplication, completeness scoring, LLM coherence review."""
+import hashlib
+import json
+import os
+import random
+from typing import List, Optional
+
+
+def deduplicate(data: List[dict]) -> List[dict]:
+    """Remove exact duplicate rows based on MD5 hash of JSON-serialized content."""
+    seen = set()
+    result = []
+    for row in data:
+        key = hashlib.md5(json.dumps(row, sort_keys=True, ensure_ascii=False).encode()).hexdigest()
+        if key not in seen:
+            seen.add(key)
+            result.append(row)
+    return result
+
+
+def score_completeness(data: List[dict]) -> dict:
+    """Return per-column completeness (fraction of non-null/non-empty values)."""
+    if not data:
+        return {}
+    columns = list(data[0].keys())
+    scores = {}
+    for col in columns:
+        filled = sum(
+            1 for row in data
+            if row.get(col) is not None and row.get(col) != "" and row.get(col) != "failed"
+        )
+        scores[col] = round(filled / len(data), 4)
+    return scores
+
+
+def llm_coherence_review(data: List[dict], prompt: str) -> dict:
+    """
+    Use GPT-4o-mini to review up to 5 sampled rows for realism and coherence.
+    Returns {"score": 1-10, "issues": [...], "suggestions": [...]}.
+    """
+    import openai
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+
+    sample = random.sample(data, min(5, len(data)))
+    sample_str = json.dumps(sample, indent=2, ensure_ascii=False)
+
+    client = openai.OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are a data quality evaluator. Review synthetic dataset rows for realism, "
+                    "coherence, and diversity. Return a JSON object with keys: "
+                    '"score" (integer 1-10), "issues" (list of strings), "suggestions" (list of strings).'
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Dataset context: {prompt}\n\nSample rows:\n{sample_str}\n\n"
+                    "Evaluate quality. Return ONLY valid JSON."
+                ),
+            },
+        ],
+        response_format={"type": "json_object"},
+        temperature=0.3,
+    )
+    raw = response.choices[0].message.content
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"score": 0, "issues": ["Could not parse LLM response"], "suggestions": []}
+
+
+def score_dataset(data: List[dict], prompt: str = "", run_llm_review: bool = False) -> dict:
+    """Run all quality checks and return a consolidated report."""
+    unique = deduplicate(data)
+    completeness = score_completeness(data)
+    avg_completeness = round(sum(completeness.values()) / len(completeness), 4) if completeness else 0.0
+
+    report = {
+        "total_rows": len(data),
+        "unique_rows": len(unique),
+        "duplicates_removed": len(data) - len(unique),
+        "completeness": completeness,
+        "avg_completeness": avg_completeness,
+    }
+
+    if run_llm_review and data:
+        try:
+            report["llm_review"] = llm_coherence_review(data, prompt)
+        except Exception as e:
+            report["llm_review"] = {"error": str(e)}
+
+    return report


### PR DESCRIPTION
## Summary

Implements four open issues in a single PR.

### CORS — Closes #31
- Added `flask-cors>=4.0.0` to requirements.txt
- `CORS(app)` configured in `app.py` with origins from `ALLOWED_ORIGINS` env var (default `http://localhost:3000`), allowing `GET/POST/OPTIONS` with `Content-Type` and `Authorization` headers

### Tabular Generator — Closes #46
- New `server/generators/tabular.py` with `generate_tabular_data(prompt, columns, num_rows, examples, params)`
- `params.schema`: per-column type hints (`int`, `float`, `email`, `date`, `enum`, `bool`, `uuid`, `phone`, `url`, `name`, `address`)
- Async GPT-4o-mini with `asyncio.Semaphore` (configurable concurrency, default 5)
- Wired as `task_type="tabular"` in handler registry

### Code Generator — Closes #47
- New `server/generators/code.py` with `generate_code_data(prompt, columns, num_rows, examples, params)`
- `params.code_type`: `function | unittest | bugfix | review | docstring`
- `params.language`: `python | javascript | typescript | go | rust | java | cpp | sql`
- Python syntax validation via `ast.parse()` with retry on failure
- Wired as `task_type="code"` in handler registry

### Quality Scoring — Closes #44
- New `server/utils/quality.py`: `deduplicate()` (MD5), `score_completeness()`, `llm_coherence_review()` (GPT-4o-mini), `score_dataset()`
- New `POST /public/generate/quality` endpoint: accepts `{data, prompt, run_llm_review, deduplicate}`, returns `{quality: {...}, data: [...]}`

## Test plan
- [x] 93 tests pass, 2 skipped (PyJWT unavailable in env)
- [x] CORS headers verified on OPTIONS preflight and GET /health
- [x] Tabular: schema hints, mocked API pipeline
- [x] Code: type/language validation, syntax validation, bugfix/function types
- [x] Quality: dedup, completeness, LLM review (mocked), all endpoint status codes

https://claude.ai/code/session_01DoZvWfnVi9etKFkVfq5p6k