### PR TITLE
fix: implement DB layer with graceful degradation (closes #32)

### DIFF
--- a/server/database/db.py
+++ b/server/database/db.py
@@ -1,12 +1,103 @@
-# TODO: add imports
-# schema of where we store API calls
+"""
+Database layer — MySQL with connection pooling.
+Gracefully degrades when DB_HOST is not configured (logs warning, never crashes).
+"""
+import json
+import logging
+import os
+from typing import Optional
 
-def store_generate_request(user_email, task_type, columns, prompt, num_rows):
-    conn, cursor = get_db_connection()
-    user_id = user_id_for_email(user_email)
-    cursor.execute(
-        'INSERT INTO synthetic_requests (user_id, task_type, prompt, columns, num_rows) VALUES (%s, %s, %s, %s, %s)',
-        [user_id, task_type, prompt, json.dumps(columns), num_rows]
-    )
-    conn.commit()
-    conn.close()
+logger = logging.getLogger(__name__)
+
+_pool = None
+
+
+def _get_pool():
+    global _pool
+    if _pool is not None:
+        return _pool
+    host = os.getenv("DB_HOST")
+    if not host:
+        return None
+    try:
+        import mysql.connector.pooling as _pooling
+        _pool = _pooling.MySQLConnectionPool(
+            pool_name="synth_pool",
+            pool_size=5,
+            host=host,
+            port=int(os.getenv("DB_PORT", "3306")),
+            user=os.getenv("DB_USER", "root"),
+            password=os.getenv("DB_PASSWORD", ""),
+            database=os.getenv("DB_NAME", "synthetic_data"),
+        )
+        return _pool
+    except Exception as e:
+        logger.warning("DB pool init failed (non-fatal): %s", e)
+        return None
+
+
+def get_db_connection():
+    """Return a connection from the pool, or None if DB is unavailable."""
+    pool = _get_pool()
+    if pool is None:
+        return None
+    try:
+        return pool.get_connection()
+    except Exception as e:
+        logger.warning("DB connection failed (non-fatal): %s", e)
+        return None
+
+
+def user_id_for_email(conn, email: str) -> Optional[int]:
+    """Upsert user by email and return their ID."""
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM users WHERE email = %s", (email,))
+        row = cursor.fetchone()
+        if row:
+            return row[0]
+        cursor.execute("INSERT INTO users (email) VALUES (%s)", (email,))
+        conn.commit()
+        return cursor.lastrowid
+    except Exception as e:
+        logger.warning("user_id_for_email failed (non-fatal): %s", e)
+        return None
+    finally:
+        try:
+            cursor.close()
+        except Exception:
+            pass
+
+
+def store_generate_request(
+    user_email: str,
+    task_type: str,
+    columns: list,
+    prompt: str,
+    num_rows: int,
+    status: str = "completed",
+    error: Optional[str] = None,
+    duration_ms: Optional[int] = None,
+) -> None:
+    """Log a generation request. Silently skips if DB is unavailable."""
+    conn = get_db_connection()
+    if conn is None:
+        logger.debug("DB unavailable — skipping request log for %s", user_email)
+        return
+    try:
+        user_id = user_id_for_email(conn, user_email)
+        cursor = conn.cursor()
+        cursor.execute(
+            """INSERT INTO synthetic_requests
+               (user_id, task_type, prompt, columns, num_rows, status, error, duration_ms)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s)""",
+            (user_id, task_type, prompt, json.dumps(columns), num_rows, status, error, duration_ms),
+        )
+        conn.commit()
+    except Exception as e:
+        logger.warning("store_generate_request failed (non-fatal): %s", e)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1,12 +1,28 @@
-# TODO: update the schema
+-- Synthetic Data platform schema
+-- All tables use IF NOT EXISTS so this script is safe to re-run.
 
-CREATE TABLE synthetic_requests (
-    id INTEGER NOT NULL AUTO_INCREMENT,
-    created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    user_id INTEGER NOT NULL,
-    task_type TEXT NOT NULL,
-    prompt TEXT,
-    columns JSON NOT NULL,
-    num_rows INTEGER NOT NULL,
-    PRIMARY KEY (id)
+CREATE TABLE IF NOT EXISTS users (
+    id          INTEGER      NOT NULL AUTO_INCREMENT,
+    email       VARCHAR(255) NOT NULL UNIQUE,
+    created_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    INDEX idx_users_email (email)
+);
+
+CREATE TABLE IF NOT EXISTS synthetic_requests (
+    id          INTEGER      NOT NULL AUTO_INCREMENT,
+    user_id     INTEGER,
+    task_type   VARCHAR(50)  NOT NULL,
+    prompt      TEXT,
+    columns     JSON         NOT NULL,
+    num_rows    INTEGER      NOT NULL,
+    status      VARCHAR(20)  NOT NULL DEFAULT 'completed',
+    error       TEXT,
+    duration_ms INTEGER,
+    created_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    INDEX idx_requests_user    (user_id),
+    INDEX idx_requests_type    (task_type),
+    INDEX idx_requests_created (created_at),
+    CONSTRAINT fk_requests_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
 );

--- a/server/tests/test_db.py
+++ b/server/tests/test_db.py
@@ -1,0 +1,91 @@
+"""Tests for the database layer (issue #32)."""
+import json, os, sys, pytest
+from unittest.mock import patch, MagicMock, call
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestDbLayer:
+    def setup_method(self):
+        """Reset the pool singleton before each test."""
+        import database.db as db_mod
+        db_mod._pool = None
+
+    def test_no_db_host_returns_none_pool(self):
+        with patch.dict("os.environ", {}, clear=True):
+            from database.db import _get_pool
+            assert _get_pool() is None
+
+    def test_get_connection_returns_none_when_no_host(self):
+        with patch.dict("os.environ", {}, clear=True):
+            import database.db as db_mod
+            db_mod._pool = None
+            from database.db import get_db_connection
+            assert get_db_connection() is None
+
+    def test_store_generate_request_skips_when_no_db(self):
+        """No DB configured — store_generate_request must not raise."""
+        with patch.dict("os.environ", {}, clear=True):
+            import database.db as db_mod
+            db_mod._pool = None
+            from database.db import store_generate_request
+            store_generate_request("user@test.com", "text", ["col"], "prompt", 5)
+
+    def test_store_generate_request_with_mocked_db(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (42,)
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        import database.db as db_mod
+        db_mod._pool = None
+
+        with patch("database.db.get_db_connection", return_value=mock_conn):
+            from database.db import store_generate_request
+            store_generate_request("alice@test.com", "text", ["q", "a"], "test", 3)
+
+        # Verify INSERT was called
+        calls = [str(c) for c in mock_cursor.execute.call_args_list]
+        assert any("INSERT INTO synthetic_requests" in c for c in calls)
+
+    def test_user_id_for_email_existing_user(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (7,)
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        from database.db import user_id_for_email
+        result = user_id_for_email(mock_conn, "existing@test.com")
+        assert result == 7
+
+    def test_user_id_for_email_new_user(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+        mock_cursor.lastrowid = 99
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        from database.db import user_id_for_email
+        result = user_id_for_email(mock_conn, "new@test.com")
+        assert result == 99
+
+    def test_pool_init_failure_returns_none(self):
+        import database.db as db_mod
+        db_mod._pool = None
+        with patch.dict("os.environ", {"DB_HOST": "bad-host"}):
+            with patch("database.db._get_pool", return_value=None):
+                from database.db import get_db_connection
+                result = get_db_connection()
+        assert result is None
+
+    def test_store_request_handles_db_exception(self):
+        """DB write failure must not raise — just log."""
+        mock_conn = MagicMock()
+        mock_conn.cursor.side_effect = Exception("DB down")
+
+        import database.db as db_mod
+        db_mod._pool = None
+
+        with patch("database.db.get_db_connection", return_value=mock_conn):
+            from database.db import store_generate_request
+            store_generate_request("user@test.com", "text", ["col"], "prompt", 1)


### PR DESCRIPTION
Closes #32

- `get_db_connection()`: lazy MySQL pool via `mysql.connector.pooling`; returns `None` when `DB_HOST` unset or connection fails — server never crashes due to DB issues
- `user_id_for_email()`: upsert user by email, returns id
- `store_generate_request()`: logs full request with `status`, `error`, `duration_ms`; silently skips on any failure
- `schema.sql`: `users` table + `IF NOT EXISTS` guards, `status`/`error`/`duration_ms` columns, indexes on `user_id`/`task_type`/`created_at`
- 8 tests covering all paths; 109 total tests pass

https://claude.ai/code/session_01DoZvWfnVi9etKFkVfq5p6k