### PR TITLE
feat(#43): dataset versioning with file store and optional DB fallback

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -86,7 +86,53 @@ def generate():
     if errors:
         return jsonify({"error": "Validation failed", "details": errors}), 422
 
-    return GenerateHandler(request, user_email)
+    result = GenerateHandler(request, user_email)
+
+    # Save version snapshot (non-fatal if it fails)
+    try:
+        from utils.versioning import save_version
+        generated_data = result.get_json().get("data", [])
+        version_id = save_version(
+            user_email=user_email,
+            task_type=body.get("task_type"),
+            prompt=body.get("prompt", ""),
+            columns=body.get("columns", []),
+            params=body.get("params", {}),
+            result_data=generated_data,
+            num_rows=body.get("num_rows", 5),
+        )
+        payload = result.get_json()
+        payload["version_id"] = version_id
+        return jsonify(payload)
+    except Exception as e:
+        logger.warning("Versioning failed (non-fatal): %s", e)
+        return result
+
+
+@app.route("/public/generate/versions", methods=["GET"])
+def list_versions():
+    try:
+        user_email = extractUserEmailFromRequest(request)
+    except InvalidTokenError as e:
+        return jsonify({"error": "Invalid JWT token", "detail": str(e)}), 401
+
+    limit = min(int(request.args.get("limit", 20)), 100)
+    from utils.versioning import list_versions as _list
+    return jsonify({"versions": _list(user_email, limit)})
+
+
+@app.route("/public/generate/versions/<version_id>", methods=["GET"])
+def get_version(version_id):
+    try:
+        extractUserEmailFromRequest(request)
+    except InvalidTokenError as e:
+        return jsonify({"error": "Invalid JWT token", "detail": str(e)}), 401
+
+    from utils.versioning import get_version as _get
+    record = _get(version_id)
+    if record is None:
+        return jsonify({"error": f"Version '{version_id}' not found"}), 404
+    return jsonify(record)
 
 
 @app.route("/public/generate/export", methods=["POST"])

--- a/server/tests/test_examples.py
+++ b/server/tests/test_examples.py
@@ -108,7 +108,7 @@ class TestExampleTextRequest:
             resp = client.post("/public/generate", json=payload)
         assert resp.status_code == 200
         result = resp.get_json()
-        assert result == EXAMPLE_TEXT_RESPONSE
+        assert result["data"] == EXAMPLE_TEXT_RESPONSE["data"]
 
     def test_sentiment_dataset_generation(self, client):
         payload = {

--- a/server/tests/test_versioning.py
+++ b/server/tests/test_versioning.py
@@ -1,0 +1,109 @@
+"""Tests for dataset versioning (issue #43)."""
+import json, os, sys, uuid, pytest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("REPLICATE_API_TOKEN", "test-token")
+os.environ.setdefault("SYNTHETIC_OUTPUT_DIR", "/tmp/synthetic-test-output")
+
+SAMPLE_ROWS = [{"q": "Q1", "a": "A1", "status": "succeeded"}]
+
+
+class TestVersioningUtils:
+    def test_save_version_returns_uuid(self, tmp_path):
+        with patch("utils.versioning._VERSIONS_DIR", tmp_path):
+            from utils.versioning import save_version
+            vid = save_version("u@t.com", "text", "prompt", ["q"], {}, SAMPLE_ROWS, 1)
+        assert uuid.UUID(vid)  # valid UUID
+
+    def test_save_version_creates_file(self, tmp_path):
+        with patch("utils.versioning._VERSIONS_DIR", tmp_path):
+            from utils.versioning import save_version
+            vid = save_version("u@t.com", "text", "prompt", ["q"], {}, SAMPLE_ROWS, 1)
+        assert (tmp_path / f"{vid}.json").exists()
+
+    def test_get_version_roundtrip(self, tmp_path):
+        with patch("utils.versioning._VERSIONS_DIR", tmp_path):
+            from utils.versioning import save_version, get_version
+            vid = save_version("u@t.com", "text", "my prompt", ["q"], {}, SAMPLE_ROWS, 1)
+            record = get_version(vid)
+        assert record["version_id"] == vid
+        assert record["prompt"] == "my prompt"
+        assert record["result_data"] == SAMPLE_ROWS
+
+    def test_get_version_not_found_returns_none(self, tmp_path):
+        with patch("utils.versioning._VERSIONS_DIR", tmp_path):
+            from utils.versioning import get_version
+            assert get_version("nonexistent-id") is None
+
+    def test_list_versions_returns_user_records(self, tmp_path):
+        with patch("utils.versioning._VERSIONS_DIR", tmp_path):
+            from utils.versioning import save_version, list_versions
+            save_version("alice@t.com", "text", "p1", ["q"], {}, SAMPLE_ROWS, 1)
+            save_version("alice@t.com", "image", "p2", ["img"], {}, SAMPLE_ROWS, 1)
+            save_version("bob@t.com", "text", "p3", ["q"], {}, SAMPLE_ROWS, 1)
+            versions = list_versions("alice@t.com")
+        assert len(versions) == 2
+        assert all(v["user_email"] == "alice@t.com" for v in versions)
+
+    def test_list_versions_excludes_result_data(self, tmp_path):
+        with patch("utils.versioning._VERSIONS_DIR", tmp_path):
+            from utils.versioning import save_version, list_versions
+            save_version("u@t.com", "text", "p", ["q"], {}, SAMPLE_ROWS, 1)
+            versions = list_versions("u@t.com")
+        assert "result_data" not in versions[0]
+
+    def test_save_version_tolerates_write_failure(self):
+        from utils.versioning import save_version
+        with patch("utils.versioning._versions_dir", side_effect=OSError("disk full")):
+            vid = save_version("u@t.com", "text", "p", ["q"], {}, SAMPLE_ROWS, 1)
+        assert uuid.UUID(vid)  # still returns a UUID
+
+
+class TestVersioningEndpoints:
+    def test_generate_returns_version_id(self, client):
+        mock_rows = [{"q": "Q1", "a": "A1", "status": "succeeded"}]
+        with patch("generators.text.generate_text_data", return_value=mock_rows), \
+             patch("utils.versioning.save_version", return_value="test-uuid-1234"):
+            resp = client.post("/public/generate", json={
+                "task_type": "text", "prompt": "test", "num_rows": 1, "columns": ["q", "a"],
+            })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "version_id" in body
+        assert body["version_id"] == "test-uuid-1234"
+
+    def test_list_versions_endpoint(self, client, tmp_path):
+        with patch("utils.versioning._VERSIONS_DIR", tmp_path):
+            from utils.versioning import save_version
+            with patch("app.extractUserEmailFromRequest", return_value="test@example.com"):
+                save_version("test@example.com", "text", "p", ["q"], {}, SAMPLE_ROWS, 1)
+            resp = client.get("/public/generate/versions")
+        assert resp.status_code == 200
+        assert "versions" in resp.get_json()
+
+    def test_get_version_endpoint(self, client, tmp_path):
+        with patch("utils.versioning._VERSIONS_DIR", tmp_path):
+            from utils.versioning import save_version
+            vid = save_version("test@example.com", "text", "prompt", ["q"], {}, SAMPLE_ROWS, 1)
+            resp = client.get(f"/public/generate/versions/{vid}")
+        assert resp.status_code == 200
+        assert resp.get_json()["version_id"] == vid
+
+    def test_get_version_not_found_returns_404(self, client, tmp_path):
+        with patch("utils.versioning._VERSIONS_DIR", tmp_path):
+            resp = client.get("/public/generate/versions/does-not-exist")
+        assert resp.status_code == 404
+
+    def test_list_versions_401_on_bad_auth(self, client):
+        from auth_utils import InvalidTokenError
+        with patch("app.extractUserEmailFromRequest", side_effect=InvalidTokenError("no")):
+            resp = client.get("/public/generate/versions")
+        assert resp.status_code == 401
+
+    def test_get_version_401_on_bad_auth(self, client):
+        from auth_utils import InvalidTokenError
+        with patch("app.extractUserEmailFromRequest", side_effect=InvalidTokenError("no")):
+            resp = client.get("/public/generate/versions/some-id")
+        assert resp.status_code == 401

--- a/server/utils/versioning.py
+++ b/server/utils/versioning.py
@@ -1,0 +1,131 @@
+"""
+Dataset versioning — stores generation snapshots as JSON files.
+Falls back gracefully when DB is unavailable; always returns a version_id.
+"""
+import json
+import logging
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_VERSIONS_DIR = Path(os.getenv("SYNTHETIC_OUTPUT_DIR", "./outputs")) / "versions"
+
+
+def _versions_dir() -> Path:
+    d = _VERSIONS_DIR
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def save_version(
+    user_email: str,
+    task_type: str,
+    prompt: str,
+    columns: list,
+    params: dict,
+    result_data: list,
+    num_rows: int,
+) -> str:
+    """
+    Persist a generation snapshot and return a UUID version_id.
+    Never raises — on failure logs a warning and still returns a UUID.
+    """
+    version_id = str(uuid.uuid4())
+    record = {
+        "version_id": version_id,
+        "user_email": user_email,
+        "task_type": task_type,
+        "prompt": prompt,
+        "columns": columns,
+        "params": params,
+        "num_rows": num_rows,
+        "row_count": len(result_data),
+        "status": "completed",
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "result_data": result_data,
+    }
+    try:
+        path = _versions_dir() / f"{version_id}.json"
+        path.write_text(json.dumps(record, ensure_ascii=False, indent=2))
+    except Exception as e:
+        logger.warning("Could not persist version %s: %s", version_id, e)
+
+    # Also try DB if available
+    try:
+        from database.db import get_db_connection
+        conn = get_db_connection()
+        if conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """INSERT INTO generation_versions
+                   (version_id, user_email, task_type, prompt, columns, params,
+                    result_data, row_count, status)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                (
+                    version_id, user_email, task_type, prompt,
+                    json.dumps(columns), json.dumps(params),
+                    json.dumps(result_data), len(result_data), "completed",
+                ),
+            )
+            conn.commit()
+            conn.close()
+    except Exception:
+        pass  # DB optional — file store is the fallback
+
+    return version_id
+
+
+def get_version(version_id: str) -> Optional[dict]:
+    """Return the full version record, or None if not found."""
+    # Try file store first
+    try:
+        path = _versions_dir() / f"{version_id}.json"
+        if path.exists():
+            return json.loads(path.read_text())
+    except Exception as e:
+        logger.warning("Could not read version file %s: %s", version_id, e)
+
+    # Try DB fallback
+    try:
+        from database.db import get_db_connection
+        conn = get_db_connection()
+        if conn:
+            cursor = conn.cursor(dictionary=True)
+            cursor.execute(
+                "SELECT * FROM generation_versions WHERE version_id = %s", (version_id,)
+            )
+            row = cursor.fetchone()
+            conn.close()
+            if row:
+                for field in ("columns", "params", "result_data"):
+                    if isinstance(row.get(field), str):
+                        row[field] = json.loads(row[field])
+                return row
+    except Exception:
+        pass
+
+    return None
+
+
+def list_versions(user_email: str, limit: int = 20) -> list:
+    """Return recent version metadata (without result_data) for a user."""
+    versions = []
+    try:
+        d = _versions_dir()
+        files = sorted(d.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+        for f in files:
+            try:
+                record = json.loads(f.read_text())
+                if record.get("user_email") == user_email:
+                    versions.append({k: v for k, v in record.items() if k != "result_data"})
+                    if len(versions) >= limit:
+                        break
+            except Exception:
+                continue
+    except Exception as e:
+        logger.warning("Could not list versions: %s", e)
+    return versions


### PR DESCRIPTION
## Summary
- Adds `server/utils/versioning.py` with `save_version`, `get_version`, `list_versions`
- Snapshots stored as UUID-named JSON files under `outputs/versions/`; MySQL is optional secondary store
- `/public/generate` now returns `version_id` in response
- New endpoints: `GET /public/generate/versions` and `GET /public/generate/versions/<version_id>`
- 13 new tests in `test_versioning.py`; all 130 tests pass

## Test plan
- [x] `pytest tests/` — 130 passed, 2 skipped
- [x] Versioning works without DB (file-only fallback)
- [x] `version_id` present in generate response

https://claude.ai/code/session_01DoZvWfnVi9etKFkVfq5p6k