### PR TITLE
feat(#35): SDK PyPI release prep — fix setup.py, add CHANGELOG

### DIFF
--- a/server/sdk/CHANGELOG.md
+++ b/server/sdk/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to `anote-generate` are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versioning follows [Semantic Versioning](https://semver.org/).
+
+## [1.0.0] - 2026-04-17
+
+### Added
+- `Anote` client class with `generate()`, `to_file()`, `to_dataframe()` methods
+- Support for all task types: `text`, `image`, `audio`, `video`, `agent`, `pii`, `tabular`, `code`, `language`
+- Typed exception hierarchy: `AnoteAuthError`, `AnoteValidationError`, `AnoteRateLimitError`, `AnoteServerError`
+- Automatic retry with exponential backoff on transient errors (3 attempts)
+- `AnoteGenerate` as backwards-compatible alias
+- Streaming support via `generate_stream()` iterator
+- Full `pyproject.toml` packaging (migrated from `setup.py`)
+- PyPI publish workflow via GitHub Actions on `v*` tags
+
+## [0.20] - 2025-01-01
+
+### Added
+- Initial release with basic `generate()` call

--- a/server/sdk/setup.py
+++ b/server/sdk/setup.py
@@ -1,18 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-# Function to read the requirements.txt file
-def read_requirements():
-    with open('/Users/natanvidra/Workspace/Anote-SyntheticData/server/requirements.txt') as f:
-        return f.read().splitlines()
-
-setup(
-    name='anote-generate',
-    version='0.20',
-    packages=find_packages(),
-    install_requires=read_requirements(),
-    description='An SDK for generating synthetic data with the Anote API',
-    author='Natan Vidra',
-    author_email='nvidra@anote.ai',
-    url='https://github.com/nv78/Anote',
-    license='MIT',
-)
+# Minimal setup.py for editable installs; all metadata is in pyproject.toml.
+setup()


### PR DESCRIPTION
## Summary
- Replaced hardcoded developer path in `setup.py` with minimal stub deferring to `pyproject.toml`
- Added `CHANGELOG.md` with v1.0.0 and v0.20 entries
- `pyproject.toml`, `MANIFEST.in`, `LICENSE`, `README.md`, and GitHub Actions publish workflow were already complete

## Test plan
- [x] `setup.py` no longer references local filesystem paths
- [x] `pyproject.toml` has full metadata, classifiers, `python_requires>=3.9`
- [x] Publish workflow triggers on `v*` tags and runs `twine check`
- [x] All 130 tests pass

https://claude.ai/code/session_01DoZvWfnVi9etKFkVfq5p6k