### PR TITLE
docs(#51): overhaul README with accurate structure, quick start, and API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,230 +1,335 @@
-# SyntheticDataGen — API & Project Overview
+# Anote Synthetic Data
 
-**Driving Frontier AI with Expert Data**
-SyntheticDataGen is Anote’s SDK + API for programmatic dataset **generation, curation, labeling, and evaluation** across **text, images, video, audio, and agent traces**. It provides a single `generate(...)` interface, modality-specific generators, built-in quality checks, and evaluation hooks so teams can go from **prompt → validated data → benchmark-ready splits** with minimal glue code.
+[![CI](https://github.com/anote-ai/Synthetic-Data/actions/workflows/ci.yml/badge.svg)](https://github.com/anote-ai/Synthetic-Data/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/anote-generate)](https://pypi.org/project/anote-generate/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](server/sdk/LICENSE)
 
-
-## Resources
-
-- **Datasets & Services:** https://anote.ai/syntheticdata
-- **Anote API docs (patterns to mirror):** https://docs.anote.ai/api-anote/predict.html
-
-## Presentations:
-Synthetic Data Launch:
-https://www.youtube.com/watch?v=Qj653H5hvIw
-
-Synthetic Data and Natural Language Processing - Ishaana Rao
-https://www.youtube.com/watch?v=5SpeMMJMiyk
-
-Synthetic Data Generation (Training Dataset Curation) - Zexun Yao
-https://www.youtube.com/watch?v=nuvZHkuKWgQ
-
-Synthetic Data Generation (API) - Saumya Singh
-https://www.youtube.com/watch?v=v2OSiva-s0c
+Multi-modal synthetic dataset generation platform. Generate text, image, audio, video, PII, tabular, code, and language datasets via a unified REST API or Python SDK.
 
 ---
 
-## Why Synthetic Datasets (Train & Eval) Matter
-
-- **Coverage & Scale.** Real-world data is sparse on edge cases; synthetic data fills long-tail gaps and supports rapid iteration at scale.
-- **Speed to Insight.** New tasks/models need prototypes **now** (hours/days), not weeks of collection and labeling.
-- **Controlled Difficulty.** Dial task difficulty, domain shift, noise, and adversarial patterns to stress-test models.
-- **Privacy & Compliance.** Generate PII-safe surrogates or redact/templated records to avoid handling sensitive source data.
-- **Reproducibility.** Seeds + manifests make experiments repeatable and auditable for research and regulated settings.
-
-### Training vs Evaluation
-- **Training sets** teach skills (breadth & diversity).
-- **Evaluation sets** independently measure progress (held-out, well-specified, stable).
-SyntheticDataGen supports both, plus **stress tests** (robustness, bias, safety) and **leaderboard submissions**.
-
----
-
-## Today’s Manual Curation Workflow (Typical) — and Pain Points
-
-1. Define task, schema, and label space
-2. Gather raw data (scrape, export, purchase)
-3. Draft labeling guide; train annotators
-4. Label in tools; export; fix schema mismatches
-5. QA passes (spot-check, inter-annotator agreement)
-6. Dedupe, split, document, version, and store
-7. Run baselines; realize you need **more edge cases** → loop back
-
-**Pain points:** slow/expensive, inconsistent quality, drift across versions, weak long-tail coverage, privacy constraints, and poor reproducibility.
-
-**SyntheticDataGen** automates most steps: **programmatic generation**, **schema-aware QA**, **LLM review**, **benchmark hooks**, and **versioned artifacts**.
-
----
-
-## Supported Task Types (by Modality)
-
-**Text**
-- **Classification:** e.g., Amazon review sentiment (positive/negative/neutral)
-- **NER:** e.g., PII tagging with labeled entities
-- **Chatbot:** e.g., Japanese conversational pairs for assistants
-- **Prompting/IE:** e.g., extract structured fields from 10-K filings
-
-**Images**
-- **Object Detection:** e.g., undersea imagery with bounding boxes
-- **Image Generation:** prompts → synthetic images for diffusion/GenAI
-
-**Video**
-- **Video–Prompt Pairs:** `.mp4` clips + JSON metadata for Veo/Sora-style models
-
-**Audio**
-- **TTS/ASR Data:** `.wav` + transcripts, speaker/noise profiles
-
-**Agents**
-- **Agent Traces:** sequences of tool calls, actions, observations, rewards (browser/OS/multi-agent)
-
----
-
-## Where to Find Datasets
-
-Explore curated and sample datasets on the Anote site:
-**https://anote.ai/syntheticdata**
-
-You’ll find task cards, example artifacts, and links to request bespoke datasets.
-
----
-
-## Repository Layout (reference)
-
-```
-anote-generate/
-├─ setup.py                      # package: anote-generate
-├─ requirements.txt
-├─ anotegenerate/
-│  ├─ __init__.py
-│  ├─ core.py                    # exposes generate(...)
-│  └─ Generators/
-│     ├─ text.py | image.py | video.py | audio.py | agents.py
-├─ api_endpoints/handler.py      # Flask routes (POST /generate)
-├─ app.py                        # Flask entrypoint
-├─ db.py                         # DB connections/queries
-├─ schema.sql                    # jobs, artifacts, rows, metrics
-├─ examples/
-│  ├─ examples_data/             # CSV/JSON + media
-│  ├─ text.py | image.py | video.py | audio.py | agents.py
-└─ docs/
-   ├─ markdown.md                # API usage, IO fields, params
-   └─ synthetic/example1.md      # worked example
-```
-
----
-
-## Install & Run
+## Quick Start
 
 ```bash
-# clone your repo (example)
-git clone repo
+# 1. Clone
+git clone https://github.com/anote-ai/Synthetic-Data.git
+cd Synthetic-Data
 
-# install
-pip install -r requirements.txt
-pip install -e .
+# 2. Configure
+cp .env.example .env
+# Fill in OPENAI_API_KEY (required) and REPLICATE_API_TOKEN (video only)
 
-# credentials (as needed)
-export SYNTHETIC_DATA_API_KEY="your_api_key"
-export OPENAI_API_KEY="your_openai_key"
+# 3. Start everything (Docker)
+make docker-up
 
-# optional: local YOLO server for image tasks
-export YOLO_SERVER_URL="http://localhost:5001"
-
-# run API
-python app.py
+# 4. Verify
+curl http://localhost:5000/health
+# {"status": "ok"}
 ```
+
+Or run the server manually:
+
+```bash
+cd server
+python -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+python app.py          # http://localhost:5000
+```
+
+---
+
+## Repository Structure
+
+```
+Synthetic-Data/
+├── server/
+│   ├── app.py                    # Flask entrypoint — all REST routes
+│   ├── requirements.txt
+│   ├── Dockerfile
+│   ├── api_endpoints/handler.py  # routes task_type → generator
+│   ├── generators/               # one file per modality
+│   │   ├── text.py               # stub (mock data)
+│   │   ├── image.py              # DALL-E 3 + YOLO11 detection
+│   │   ├── video.py              # Replicate async + GPT-4o Vision
+│   │   ├── audio.py              # faster-whisper TTS/ASR
+│   │   ├── PII.py                # 14 PII types, async LLM
+│   │   ├── Language.py           # multilingual Q&A, async
+│   │   ├── tabular.py            # typed tabular, async
+│   │   └── code.py               # code generation + validation
+│   ├── utils/
+│   │   ├── versioning.py         # dataset snapshot store
+│   │   ├── export.py             # CSV/JSONL/Parquet export
+│   │   └── quality.py            # completeness + LLM review
+│   ├── database/
+│   │   ├── db.py                 # MySQL pool, graceful fallback
+│   │   └── schema.sql
+│   └── tests/
+├── server/sdk/                   # pip install anote-generate
+│   ├── pyproject.toml
+│   ├── anote-generate/
+│   │   ├── __init__.py
+│   │   └── core.py
+│   └── CHANGELOG.md
+├── frontend/                     # React 18 UI
+│   ├── Dockerfile
+│   └── src/App.js
+├── docker-compose.yml
+├── docker-compose.override.yml   # dev hot-reload
+├── Makefile
+└── .env.example
+```
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OPENAI_API_KEY` | Yes | — | OpenAI API key (text, image, PII, language, code) |
+| `REPLICATE_API_TOKEN` | Video only | — | Replicate API token for video generation |
+| `DB_HOST` | No | — | MySQL host; omit to disable DB logging |
+| `DB_PORT` | No | `3306` | MySQL port |
+| `DB_USER` | No | `root` | MySQL user |
+| `DB_PASSWORD` | No | `""` | MySQL password |
+| `DB_NAME` | No | `synthetic_data` | MySQL database name |
+| `ALLOWED_ORIGINS` | No | `http://localhost:3000` | CORS allowed origins (comma-separated) |
+| `MAX_ROWS_PER_REQUEST` | No | `100` | Maximum rows per `/public/generate` call |
+| `SYNTHETIC_OUTPUT_DIR` | No | `./outputs` | Directory for generated files and version snapshots |
+| `REACT_APP_API_BASE_URL` | No | `http://localhost:5000` | Backend URL used by React frontend build |
 
 ---
 
 ## API Reference
 
-### `POST /generate`
+All endpoints require `Content-Type: application/json` and an `Authorization: Bearer <token>` header.
 
-**Request (JSON)**
+### `GET /health`
+
+Returns `{"status": "ok"}`. No auth required.
+
+---
+
+### `POST /public/generate`
+
+Generate a synthetic dataset.
+
+**Request body:**
 ```json
 {
   "task_type": "text",
-  "prompt": "Amazon movie review sentiment dataset",
-  "num_rows": 500,
-  "columns": ["text", "label"],
+  "prompt": "Generate Q&A pairs about Python programming",
+  "num_rows": 10,
+  "columns": ["question", "answer", "difficulty"],
   "examples": [
-    {"text": "I loved the cinematography.", "label": "positive"},
-    {"text": "It dragged on and on.", "label": "negative"}
+    {"question": "What is a list?", "answer": "An ordered collection", "difficulty": "easy"}
   ],
-  "params": {
-    "label_set": ["positive", "negative", "neutral"],
-    "languages": ["en"],
-    "domain": "movies"
-  },
-  "output_format": "csv",
-  "media_dir": "examples/examples_data",
-  "seed": 42
+  "params": {}
 }
 ```
 
-**Response**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `task_type` | string | Yes | `text` \| `image` \| `video` \| `audio` \| `agent` \| `pii` \| `language` \| `tabular` \| `code` |
+| `prompt` | string | Yes | Natural language description of the dataset |
+| `num_rows` | int | No | Rows to generate (default 5, max 100) |
+| `columns` | list[str] | Yes | Output column names |
+| `examples` | list[dict] | No | Few-shot examples to guide generation |
+| `params` | dict | No | Modality-specific parameters (see below) |
+
+**Response:**
 ```json
 {
-  "job_id": "gen_01H8YX...",
-  "artifact": {
-    "table_path": "examples/examples_data/reviews.csv",
-    "media_manifest": null
-  },
-  "summary": {
-    "rows": 500,
-    "modality": "text",
-    "quality_checks": ["heuristic", "llm_review", "benchmark_compare"]
-  }
+  "data": [
+    {"question": "What is a decorator?", "answer": "A function wrapper", "difficulty": "medium", "status": "succeeded"},
+    {"status": "failed", "error": "..."}
+  ],
+  "version_id": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-**Common Fields**
-- `task_type`: `"text" | "image" | "video" | "audio" | "agents"`
-- `prompt`: Natural language spec for generation
-- `num_rows`: Number of rows/samples to generate
-- `columns`: Output schema fields (e.g., `["text","label"]`)
-- `examples`: Few-shot examples to steer outputs
-- `params`: Modality-specific options
-- `output_format`: `"csv" | "json" | "parquet"`
-- `media_dir`: Where to write `.png/.mp4/.wav` and manifests
-- `seed`: Integer for reproducibility
+---
+
+### `POST /public/generate/stream`
+
+Same request body as `/public/generate`. Returns `text/event-stream` (SSE) with one row per event:
+
+```
+data: {"type": "progress", "row": 0, "total": 10, "data": {...}}
+data: {"type": "progress", "row": 1, "total": 10, "data": {...}}
+data: {"type": "done", "total_rows": 10}
+```
+
+---
+
+### `POST /public/generate/export`
+
+Generate and immediately download as a file.
+
+```json
+{
+  "format": "csv",
+  "filename": "my_dataset",
+  "task_type": "text",
+  "prompt": "...",
+  "columns": ["col1"],
+  "num_rows": 20
+}
+```
+
+Supported formats: `csv`, `jsonl`, `parquet`, `json`.
+
+---
+
+### `POST /public/generate/quality`
+
+Score a dataset for completeness and optionally run an LLM coherence review.
+
+```json
+{
+  "data": [{"col": "val"}, ...],
+  "prompt": "optional context for LLM review",
+  "run_llm_review": true,
+  "deduplicate": false
+}
+```
+
+---
+
+### `GET /public/generate/versions`
+
+List recent generation snapshots for the authenticated user.
+
+Query params: `limit` (default 20, max 100).
+
+---
+
+### `GET /public/generate/versions/<version_id>`
+
+Retrieve a full generation snapshot including result data.
+
+---
+
+## Task-specific `params`
+
+| `task_type` | Key params |
+|-------------|-----------|
+| `language` | `language` (e.g. "Japanese"), `model`, `concurrency` |
+| `video` | `fps`, `resolution`, `duration`, `annotate_frames`, `num_keyframes` |
+| `audio` | `voice`, `tts_model`, `speed` |
+| `image` | `image_size`, `style`, `run_detection` |
+| `tabular` | `schema` (per-column type hints) |
+| `code` | `code_type` (`function`\|`unittest`\|`bugfix`\|`review`\|`docstring`), `language` |
+| `pii` | `pii_types`, `locale` |
 
 ---
 
 ## Python SDK
 
-```python
-from anotegenerate import generate
+```bash
+pip install anote-generate
+```
 
-result = generate(
+```python
+from anote_generate import Anote
+
+client = Anote(api_key="your-key")  # or set ANOTE_API_KEY env var
+
+rows = client.generate(
     task_type="text",
-    prompt="Amazon movie review sentiment dataset",
-    num_rows=500,
-    columns=["text", "label"],
-    examples=[
-        {"text": "I loved the cinematography.", "label": "positive"},
-        {"text": "It dragged on and on.", "label": "negative"},
-    ],
-    params={"label_set": ["positive", "negative", "neutral"], "languages": ["en"]},
-    output_format="csv",
-    media_dir="examples/examples_data",
-    seed=42
+    columns=["question", "answer"],
+    prompt="Generate Q&A pairs about Python programming",
+    num_rows=10,
+    examples=[{"question": "What is a list?", "answer": "An ordered collection"}],
 )
 
-print("Dataset at:", result.path)
+# Save results
+client.to_file(rows, "dataset.csv")        # CSV
+client.to_file(rows, "dataset.jsonl")      # JSONL
+df = client.to_dataframe(rows)             # pandas DataFrame
+```
+
+**Error handling:**
+```python
+from anote_generate import AnoteAuthError, AnoteValidationError
+
+try:
+    rows = client.generate(task_type="text", columns=["col"], prompt="...", num_rows=5)
+except AnoteAuthError:
+    print("Invalid API key")
+except AnoteValidationError as e:
+    print("Bad request:", e.details)
 ```
 
 ---
 
-## Quality Assurance & Evaluation
+## Frontend Setup
 
-**Multi-layer QA**
-1. **Heuristics:** schema/label checks, length, dedupe, leakage guards
-2. **AI Review:** LLM spot-checks for label consistency, red flags
-3. **Refinement:** regenerate failures with controlled variation
-4. **Benchmark Compare:** run quick baselines to gauge dataset utility
+```bash
+cd frontend
+npm install
+npm start    # http://localhost:3000 — connects to http://localhost:5000
+```
 
-**Artifacts**
-- **Tables:** CSV/JSON/Parquet with splits + metadata
-- **Media:** images/video/audio linked via manifest
-- **Manifests:** map row IDs ↔ files
-- **Metrics:** stored per job in `metrics` table
+To point at a different backend:
+
+```bash
+REACT_APP_API_BASE_URL=https://api.example.com npm start
+```
+
+---
+
+## Running Tests
+
+```bash
+make test           # pytest with short traceback
+make test-cov       # pytest with HTML coverage report
+```
+
+Coverage target: 80%+ (enforced in CI).
+
+---
+
+## Docker
+
+```bash
+make docker-up      # start api, frontend, db, redis
+make docker-down    # stop all services
+make docker-logs    # tail api logs
+```
+
+For development (hot reload):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml up
+```
+
+---
+
+## Troubleshooting
+
+**`OPENAI_API_KEY` not set** — Copy `.env.example` to `.env` and add your key.
+
+**CORS errors in browser** — Set `ALLOWED_ORIGINS=http://localhost:3000` in `.env` (already the default).
+
+**`YOLO model not found`** — Image generation downloads `yolo11n.pt` on first run. Ensure write access to the working directory.
+
+**Video generation hangs** — Set `REPLICATE_API_TOKEN` in `.env`. Video jobs can take 2–10 minutes; the async poller retries with backoff up to ~30 minutes.
+
+**MySQL connection warnings** — Safe to ignore; the server uses file-based storage as fallback when `DB_HOST` is not set.
+
+---
+
+## Contributing
+
+1. Fork the repo and create a branch: `git checkout -b feat/my-feature`
+2. Make changes, add tests: `make test`
+3. Push and open a PR against `main`
+4. CI must pass (pytest + coverage threshold)
+
+Branch naming: `feat/<name>`, `fix/<name>`, `chore/<name>`.
+
+---
+
+## License
+
+MIT — see [server/sdk/LICENSE](server/sdk/LICENSE).


### PR DESCRIPTION
## Summary
- Complete rewrite of README.md
- Correct repo structure matching actual directory layout
- Docker quick start: `cp .env.example .env && make docker-up`
- Full environment variables table with descriptions and defaults
- API reference for all 7 endpoints with request/response examples
- Task-specific `params` table for all modalities
- SDK usage with correct import (`from anote_generate import Anote`)
- Frontend setup section
- Troubleshooting section covering common errors
- Contributing guide with branch naming and CI requirements
- CI and PyPI badges
- Removes all references to `natanvidra` paths, old `anotegenerate` import, and outdated structure

## Test plan
- [x] All code examples use correct imports and match actual implementation
- [x] No references to old paths or class names
- [x] 141 tests still pass

https://claude.ai/code/session_01DoZvWfnVi9etKFkVfq5p6k