### PR TITLE
Add task types discovery endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Returns `{"status": "ok"}`. No auth required.
 
 ---
 
+### `GET /public/generate/task-types`
+
+Returns the task types supported by the generation API and the configured maximum row limit. No auth required.
+
+---
+
 ### `POST /public/generate`
 
 Generate a synthetic dataset.

--- a/server/app.py
+++ b/server/app.py
@@ -52,6 +52,15 @@ def health():
     return jsonify({"status": "ok"})
 
 
+@app.route("/public/generate/task-types", methods=["GET"])
+def list_task_types():
+    """Return generation task types supported by the public API."""
+    return jsonify({
+        "task_types": sorted(VALID_TASK_TYPES),
+        "max_rows_per_request": MAX_ROWS,
+    })
+
+
 @app.route("/public/generate", methods=["POST"])
 def generate():
     if not request.is_json:

--- a/server/tests/test_generate.py
+++ b/server/tests/test_generate.py
@@ -12,6 +12,25 @@ class TestHealthEndpoint:
         assert data["status"] == "ok"
 
 
+class TestTaskTypesEndpoint:
+    def test_task_types_are_discoverable(self, client):
+        resp = client.get("/public/generate/task-types")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["task_types"] == [
+            "agent",
+            "audio",
+            "code",
+            "image",
+            "language",
+            "pii",
+            "tabular",
+            "text",
+            "video",
+        ]
+        assert data["max_rows_per_request"] == 100
+
+
 class TestValidation:
     def test_missing_task_type(self, client):
         resp = client.post("/public/generate", json={


### PR DESCRIPTION
## Summary
- Add a public task types discovery endpoint for generation clients
- Return the configured max rows per request alongside supported task types
- Document the new endpoint in README

## Tests
- `.venv/bin/pytest server/tests/test_generate.py -v --tb=short`
- `cd server && ../.venv/bin/pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=50`

## Local verification
- Started Flask with `flask --app app run --host 127.0.0.1 --port 5000`
- Verified `/health` and `/public/generate/task-types`